### PR TITLE
Even more relative baseUrl.

### DIFF
--- a/alfresco-module/src/main/webapp/scripts/dynamic-extensions/coffeescript/application.coffee
+++ b/alfresco-module/src/main/webapp/scripts/dynamic-extensions/coffeescript/application.coffee
@@ -21,7 +21,7 @@ App.Api = Em.Object.extend
 
   # Configuration
   
-  baseUri: 'http://localhost:8080/alfresco/service'
+  baseUri: '.'
   
   managementInfoUri: (->
     @_uri('/dynamic-extensions/management/info')

--- a/alfresco-module/src/main/webapp/scripts/dynamic-extensions/javascript/application.js
+++ b/alfresco-module/src/main/webapp/scripts/dynamic-extensions/javascript/application.js
@@ -20,7 +20,7 @@
   });
 
   App.Api = Em.Object.extend({
-    baseUri: '/alfresco/service',
+    baseUri: '.',
     managementInfoUri: (function() {
       return this._uri('/dynamic-extensions/management/info');
     }).property('baseUri'),


### PR DESCRIPTION
Some alfresco installations use a different contextname then /alfresco.
So using '.' should work anywhere.
