### PR TITLE
Exception reference when deploying models

### DIFF
--- a/alfresco-api-util/src/main/java/nl/runnable/alfresco/repository/dictionary/ModelRegistrar.java
+++ b/alfresco-api-util/src/main/java/nl/runnable/alfresco/repository/dictionary/ModelRegistrar.java
@@ -56,7 +56,7 @@ public class ModelRegistrar {
 				registerModelMetadata(modelName, model);
 			} catch (final DictionaryException e) {
 				if (logger.isWarnEnabled()) {
-					logger.warn("Could not register model '{}': ", model.getName(), e.getMessage());
+					logger.warn(String.format("Could not register model '%s'", model.getName()), e);
 				}
 			}
 		}


### PR DESCRIPTION
Pass the exception to the logging statement to see the actual error in the logs.
