### PR TITLE
Disabled Alfresco parent to resolve classloader errors.

### DIFF
--- a/blueprint-integration/src/main/java/nl/runnable/alfresco/blueprint/DynamicExtensionsApplicationContext.java
+++ b/blueprint-integration/src/main/java/nl/runnable/alfresco/blueprint/DynamicExtensionsApplicationContext.java
@@ -118,8 +118,8 @@ class DynamicExtensionsApplicationContext extends OsgiBundleXmlApplicationContex
 
 	/* Operations */
 
-	DynamicExtensionsApplicationContext(final String[] configurationLocations, final ApplicationContext parent) {
-		super(configurationLocations, parent);
+	DynamicExtensionsApplicationContext(final String[] configurationLocations) {
+		super(configurationLocations);
 		hasXmlConfiguration = (configurationLocations != null && configurationLocations.length > 0);
 	}
 

--- a/blueprint-integration/src/main/java/nl/runnable/alfresco/blueprint/DynamicExtensionsApplicationContextCreator.java
+++ b/blueprint-integration/src/main/java/nl/runnable/alfresco/blueprint/DynamicExtensionsApplicationContextCreator.java
@@ -110,9 +110,8 @@ public class DynamicExtensionsApplicationContextCreator implements OsgiApplicati
 				logger.debug("Initializing Dynamic Extension '{}'.", bundle.getSymbolicName());
 			}
 		}
-		final ApplicationContext parent = getHostApplicationContext(bundleContext);
 		final DynamicExtensionsApplicationContext applicationContext = new DynamicExtensionsApplicationContext(
-				configurationLocations, parent);
+				configurationLocations);
 		applicationContext.setBundleContext(bundleContext);
 		applicationContext.setPublishContextAsService(config.isPublishContextAsService());
 		if (StringUtils.hasText(getModelLocationPattern())) {
@@ -151,16 +150,6 @@ public class DynamicExtensionsApplicationContextCreator implements OsgiApplicati
 			} catch (final BundleException e) {
 				logger.error("Error uninstalling Bundle: {}", e.getMessage(), e);
 			}
-		}
-	}
-
-	protected ApplicationContext getHostApplicationContext(final BundleContext bundleContext) {
-		final ServiceReference<?> serviceReference = getServiceReferenceWithBeanName(bundleContext,
-				ApplicationContext.class.getName(), HOST_APPLICATION_CONTEXT_BEAN_NAME);
-		if (serviceReference != null) {
-			return (ApplicationContext) bundleContext.getService(serviceReference);
-		} else {
-			return null;
 		}
 	}
 


### PR DESCRIPTION
Caused by: java.lang.ClassNotFoundException: org.apache.xalan.processor.TransformerFactoryImpl not found by swmelba.alfresco-module [13]
    at org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1460)
    at org.apache.felix.framework.BundleWiringImpl.access$400(BundleWiringImpl.java:72)
    at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:1843)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:266)
    at org.apache.felix.framework.Felix.loadBundleClass(Felix.java:1723)
    at org.apache.felix.framework.BundleImpl.loadClass(BundleImpl.java:926)
    at org.eclipse.gemini.blueprint.util.BundleDelegatingClassLoader.findClass(BundleDelegatingClassLoader.java:97)
    ... 33 more
