### PR TITLE
AnnotationBasedWebScriptHandler override

### DIFF
--- a/annotation-handling/src/main/java/nl/runnable/alfresco/webscripts/AnnotationBasedWebScript.java
+++ b/annotation-handling/src/main/java/nl/runnable/alfresco/webscripts/AnnotationBasedWebScript.java
@@ -14,7 +14,7 @@ import org.springframework.extensions.webscripts.WebScriptRequest;
 import org.springframework.extensions.webscripts.WebScriptResponse;
 import org.springframework.util.Assert;
 
-class AnnotationBasedWebScript implements WebScript {
+public class AnnotationBasedWebScript implements WebScript {
 
 	private final Description description;
 


### PR DESCRIPTION
Tiny change so I can override AnnotationBasedWebScriptHandler in my extensions.
