### PR TITLE
Add support for RequestBody annotation in webscripts

### DIFF
--- a/alfresco-integration/src/main/java/com/github/dynamicextensionsalfresco/BeanNames.java
+++ b/alfresco-integration/src/main/java/com/github/dynamicextensionsalfresco/BeanNames.java
@@ -26,6 +26,8 @@ public enum BeanNames {
 
 	HANDLER_METHOD_ARGUMENTS_RESOLVER("handlerMethodArgumentsResolver"),
 
+	MESSAGE_CONVERTER_REGISTER("messageConverterRegister"),
+
 	M2_MODEL_LIST_FACTORY("m2ModelListFactoryBean"),
 
 	MODEL_REGISTRAR("modelRegistrar"),

--- a/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/AnnotationWebScript.java
+++ b/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/AnnotationWebScript.java
@@ -2,6 +2,7 @@ package com.github.dynamicextensionsalfresco.webscripts;
 
 import com.github.dynamicextensionsalfresco.webscripts.annotations.Attribute;
 import com.github.dynamicextensionsalfresco.webscripts.arguments.HandlerMethodArgumentsResolver;
+import com.github.dynamicextensionsalfresco.webscripts.messages.AnnotationWebScriptOutputMessage;
 import com.github.dynamicextensionsalfresco.webscripts.resolutions.DefaultResolutionParameters;
 import com.github.dynamicextensionsalfresco.webscripts.resolutions.Resolution;
 import com.github.dynamicextensionsalfresco.webscripts.resolutions.TemplateResolution;
@@ -258,7 +259,7 @@ public class AnnotationWebScript implements WebScript {
             }
 
 
-            AnnotationWebScriptOutputMessage outputMessage = new AnnotationWebScriptOutputMessage(request, response);
+            AnnotationWebScriptOutputMessage outputMessage = new AnnotationWebScriptOutputMessage(response);
             converter.write(returnValue, responseType, outputMessage);
 
         }

--- a/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/AnnotationWebScript.java
+++ b/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/AnnotationWebScript.java
@@ -10,7 +10,6 @@ import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.extensions.webscripts.*;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.http.converter.xml.Jaxb2RootElementHttpMessageConverter;
 import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
@@ -27,6 +26,8 @@ public class AnnotationWebScript implements WebScript {
 
 	private HandlerMethodArgumentsResolver argumentsResolver;
 
+	private MessageConverterRegistry messageConverterRegistry;
+
 	/* Configuration */
 
 	private final Description description;
@@ -37,12 +38,12 @@ public class AnnotationWebScript implements WebScript {
 
 	private final String id;
 
-    private final List<HttpMessageConverter<?>> messageConverters = new ArrayList<HttpMessageConverter<?>>();
 
 	/* Main operations */
 
 	public AnnotationWebScript(final Description description, final Object handler,
-			final HandlerMethods handlerMethods, final HandlerMethodArgumentsResolver argumentsResolver) {
+			final HandlerMethods handlerMethods, final HandlerMethodArgumentsResolver argumentsResolver,
+                               final MessageConverterRegistry messageConverterRegistry) {
 		Assert.notNull(description, "Description cannot be null.");
 		Assert.hasText(description.getId(), "No ID provided in Description.");
 		Assert.notNull(handler, "Handler cannot be null.");
@@ -52,11 +53,8 @@ public class AnnotationWebScript implements WebScript {
 		this.handler = handler;
 		this.handlerMethods = handlerMethods;
 		this.argumentsResolver = argumentsResolver;
+		this.messageConverterRegistry = messageConverterRegistry;
 		this.id = description.getId();
-
-        this.messageConverters.add(new MappingJackson2HttpMessageConverter());
-        this.messageConverters.add(new Jaxb2RootElementHttpMessageConverter());
-
 	}
 
 	public Object getHandler() {
@@ -197,7 +195,7 @@ public class AnnotationWebScript implements WebScript {
             MediaType responseType = null;
            if(defaultResponse == null && acceptResponseTypes.isEmpty()) { // no Content-Type information given anywhere
                 // both default and accept cannot be null together
-               throw new HttpMediaTypeNotSupportedException(null, getSupportedMediaTypes(), "Unable to convert, mediatype is null");
+               throw new HttpMediaTypeNotSupportedException(null, this.messageConverterRegistry.getSupportedMediaTypes(), "Unable to convert, mediatype is null");
            }
            else if (acceptResponseTypes.isEmpty()) { // use the default
                 responseType = defaultResponseType;
@@ -211,19 +209,10 @@ public class AnnotationWebScript implements WebScript {
                        }
                    }
 
-                   boolean typeFound = false;
-                   for(HttpMessageConverter messageConverter : this.messageConverters) {
-                       if (messageConverter.canWrite(returnValue.getClass(), mediaType)) {
-                           responseType = mediaType;
-                           typeFound = true;
-                           break;
-                       }
-                   }
-
-                   if (typeFound){
+                   if (this.messageConverterRegistry.carWrite(returnValue.getClass(), mediaType) != null) {
+                       responseType = mediaType;
                        break;
                    }
-
 
                }
            }
@@ -232,22 +221,15 @@ public class AnnotationWebScript implements WebScript {
                /**
                 * When there is no default, and there is no support for the headers, this exception is thrown.
                 */
-               throw new HttpMediaTypeNotAcceptableException(getSupportedMediaTypes());
+               throw new HttpMediaTypeNotAcceptableException(this.messageConverterRegistry.getSupportedMediaTypes());
            }
 
 
-            HttpMessageConverter converter = null;
-
-            for(HttpMessageConverter messageConverter : this.messageConverters){
-                if (messageConverter.canWrite(returnValue.getClass(), responseType)){
-                    converter = messageConverter;
-                    break;
-                }
-            }
+            HttpMessageConverter converter = this.messageConverterRegistry.carWrite(returnValue.getClass(), responseType);
 
             if(converter == null) {
                 // unsupported type requested
-                List<MediaType> supported = getSupportedMediaTypes();
+                List<MediaType> supported = this.messageConverterRegistry.getSupportedMediaTypes();
 
                 /**
                  * the {@link Jaxb2RootElementHttpMessageConverter} cannot convert a class
@@ -302,16 +284,6 @@ public class AnnotationWebScript implements WebScript {
 
 
 		}
-    }
-
-    @SuppressWarnings("unchecked")
-    private List<MediaType> getSupportedMediaTypes() {
-        List<MediaType> supported = new ArrayList<MediaType>();
-
-        for(HttpMessageConverter messageConverter : this.messageConverters){
-            supported.addAll(messageConverter.getSupportedMediaTypes());
-        }
-        return supported;
     }
 
     protected void invokeExceptionHandlerMethods(final Throwable exception, final AnnotationWebScriptRequest request,

--- a/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/AnnotationWebScriptBuilder.kt
+++ b/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/AnnotationWebScriptBuilder.kt
@@ -43,6 +43,13 @@ public class AnnotationWebScriptBuilder constructor(
     public fun setHandlerMethodArgumentsResolver(value:HandlerMethodArgumentsResolver){
         this.handlerMethodArgumentsResolver = value;
     }
+
+    @Autowired
+    private var messageConverterRegistry: MessageConverterRegistry? = null
+    public fun setMessageConverterRegistry(value:MessageConverterRegistry){
+        this.messageConverterRegistry = value;
+    }
+
     /* Dependencies */
 
     protected var beanFactory: ConfigurableListableBeanFactory? = null
@@ -142,7 +149,7 @@ public class AnnotationWebScriptBuilder constructor(
     }
 
     protected fun createWebScript(description: Description, handler: Any, handlerMethods: HandlerMethods): AnnotationWebScript {
-        return AnnotationWebScript(description, handler, handlerMethods, handlerMethodArgumentsResolver)
+        return AnnotationWebScript(description, handler, handlerMethods, handlerMethodArgumentsResolver, messageConverterRegistry)
     }
 
     protected fun handleHandlerMethodAnnotation(uri: Uri, method: Method, description: DescriptionImpl, baseUri: String) {

--- a/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/MessageConverterRegistry.java
+++ b/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/MessageConverterRegistry.java
@@ -1,0 +1,100 @@
+package com.github.dynamicextensionsalfresco.webscripts;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.converter.xml.Jaxb2RootElementHttpMessageConverter;
+import org.springframework.util.Assert;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class MessageConverterRegistry {
+    private final List<HttpMessageConverter<?>> messageConverters;
+
+    public MessageConverterRegistry() {
+        this.messageConverters = new ArrayList<HttpMessageConverter<?>>();
+
+        this.messageConverters.add(new MappingJackson2HttpMessageConverter());
+        this.messageConverters.add(new Jaxb2RootElementHttpMessageConverter());
+    }
+
+    /**
+     * Method to register a {@link HttpMessageConverter}. This converter can be used to serialize/deserialize
+     * Objects in webscripts. {@code null} values are not allowed.
+     * @param messageConverter The message converter that will be added to the register.
+     *                         If {@code null} is entered, an {@link IllegalArgumentException} will be thrown.
+     *
+     * @since 1.7.0
+     */
+    public void RegisterMessageConvertor(HttpMessageConverter messageConverter) {
+        Assert.notNull(messageConverter, "Cannot register 'null' as a messageConverter");
+        this.messageConverters.add(messageConverter);
+    }
+
+    /**
+     * Returns all registered {@link HttpMessageConverter} from this Register class.
+     * @return List of messageConverters
+     * @since 1.7.0
+     */
+    public List<HttpMessageConverter<?>> getMessageConverters() {
+        return messageConverters;
+    }
+
+    /**
+     * This method wraps the {@link HttpMessageConverter#canRead(Class, MediaType)} method. It will loop over all
+     * registered messageConverters and will call the canRead method on them. If a message converter can read the
+     * specified class and mediaType, it will be returned. If no converter can read, {@code null} will be returned.
+     * @param clazz the class to test for readability
+     * @param mediaType the media type to read, can be {@code null} if not specified.
+     * Typically the value of a {@code Content-Type} header.
+     * @return The first messageConverter that can read the class and mediaType. If none, value will be null.
+     * @since 1.7.0
+     */
+    public HttpMessageConverter canRead(Class<?> clazz, MediaType mediaType) {
+        for (HttpMessageConverter converter : getMessageConverters()) {
+            if (converter.canRead(clazz, mediaType)) {
+                return converter;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * This method wraps the {@link HttpMessageConverter#canWrite(Class, MediaType)} method. It will loop over all
+     * registered messageConverters and will call the canWrite method on them. The first messageConverter that is able
+     * to write the specified class and mediaType will be returned. If no converter can write, {@code null} will be
+     * returned.
+     * @param clazz the class to test for writability
+     * @param mediaType the media type to write, can be {@code null} if not specified.
+     * Typically the value of an {@code Accept} header.
+     * @return The first messageConverter that can write the class and mediaType. If none, value will be null.
+     * @since 1.7.0
+     */
+    public HttpMessageConverter carWrite(Class<?> clazz, MediaType mediaType) {
+        for (HttpMessageConverter converter : getMessageConverters()) {
+            if (converter.canWrite(clazz, mediaType)) {
+                return converter;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Return a List containing all supported {@link MediaType} objects that any registered messageConverter can support.
+     * @return List of all supported mediatypes from all registered messageConverters.
+     */
+    @SuppressWarnings("unchecked")
+    public List<MediaType> getSupportedMediaTypes() {
+        List<MediaType> supported = new ArrayList<MediaType>();
+
+        for(HttpMessageConverter messageConverter : this.messageConverters){
+            supported.addAll(messageConverter.getSupportedMediaTypes());
+        }
+        return supported;
+    }
+}

--- a/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/arguments/HandlerMethodArgumentsResolver.java
+++ b/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/arguments/HandlerMethodArgumentsResolver.java
@@ -49,6 +49,7 @@ public class HandlerMethodArgumentsResolver implements ApplicationContextAware {
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	protected void initializeArgumentResolvers() {
 		argumentResolvers = new ArrayList<ArgumentResolver<Object, Annotation>>();
+		argumentResolvers.add((ArgumentResolver) new RequestBodyArgumentResolver());
 		argumentResolvers.add((ArgumentResolver) new RequestParamArgumentResolver(getStringValueConverter()));
 		argumentResolvers.add((ArgumentResolver) new UriVariableArgumentResolver(getStringValueConverter()));
 		argumentResolvers.add((ArgumentResolver) new AttributeArgumentResolver());

--- a/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/arguments/HandlerMethodArgumentsResolver.java
+++ b/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/arguments/HandlerMethodArgumentsResolver.java
@@ -1,5 +1,6 @@
 package com.github.dynamicextensionsalfresco.webscripts.arguments;
 
+import com.github.dynamicextensionsalfresco.webscripts.MessageConverterRegistry;
 import org.osgi.framework.BundleContext;
 import org.osgi.util.tracker.ServiceTracker;
 import org.springframework.aop.support.AopUtils;
@@ -32,6 +33,8 @@ public class HandlerMethodArgumentsResolver implements ApplicationContextAware {
 
 	private StringValueConverter stringValueConverter;
 
+	private MessageConverterRegistry messageConverterRegistry;
+
     private BundleContext bundleContext;
 
 	/* Configuration */
@@ -49,7 +52,7 @@ public class HandlerMethodArgumentsResolver implements ApplicationContextAware {
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	protected void initializeArgumentResolvers() {
 		argumentResolvers = new ArrayList<ArgumentResolver<Object, Annotation>>();
-		argumentResolvers.add((ArgumentResolver) new RequestBodyArgumentResolver());
+		argumentResolvers.add((ArgumentResolver) new RequestBodyArgumentResolver(this.messageConverterRegistry));
 		argumentResolvers.add((ArgumentResolver) new RequestParamArgumentResolver(getStringValueConverter()));
 		argumentResolvers.add((ArgumentResolver) new UriVariableArgumentResolver(getStringValueConverter()));
 		argumentResolvers.add((ArgumentResolver) new AttributeArgumentResolver());
@@ -181,6 +184,14 @@ public class HandlerMethodArgumentsResolver implements ApplicationContextAware {
 	protected StringValueConverter getStringValueConverter() {
 		return stringValueConverter;
 	}
+
+    public MessageConverterRegistry getMessageConverterRegistry() {
+        return messageConverterRegistry;
+    }
+
+    public void setMessageConverterRegistry(MessageConverterRegistry messageConverterRegistry) {
+        this.messageConverterRegistry = messageConverterRegistry;
+    }
 
     public void setBundleContext(BundleContext bundleContext) {
         this.bundleContext = bundleContext;

--- a/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/arguments/RequestBodyArgumentResolver.java
+++ b/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/arguments/RequestBodyArgumentResolver.java
@@ -1,0 +1,116 @@
+package com.github.dynamicextensionsalfresco.webscripts.arguments;
+
+import com.github.dynamicextensionsalfresco.webscripts.messages.AnnotationWebScriptInputMessage;
+import org.springframework.extensions.webscripts.WebScriptRequest;
+import org.springframework.extensions.webscripts.WebScriptResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.converter.xml.Jaxb2RootElementHttpMessageConverter;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PushbackInputStream;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RequestBodyArgumentResolver implements ArgumentResolver<Object, RequestBody> {
+
+
+    private final List<HttpMessageConverter<?>> messageConverters = new ArrayList<HttpMessageConverter<?>>();
+
+    public RequestBodyArgumentResolver() {
+        this.messageConverters.add(new MappingJackson2HttpMessageConverter());
+        this.messageConverters.add(new Jaxb2RootElementHttpMessageConverter());
+    }
+
+    @Override
+    public boolean supports(Class<?> argumentType, Class<? extends Annotation> annotationType) {
+        if (RequestBody.class.equals(annotationType)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public Object resolveArgument(Class<?> argumentType, RequestBody parameterAnnotation, String name, WebScriptRequest request, WebScriptResponse response) {
+
+        String[] headerResponseTypes = request.getHeaderValues("Content-Type");
+        if (headerResponseTypes == null) {
+            // header does not exist
+            throw new RuntimeException("Missing 'Content-Type' header from request. Unable to resolve parameters.");
+        }
+
+        if (headerResponseTypes.length != 1) {
+            if (headerResponseTypes.length == 0) {
+                throw new RuntimeException("Missing 'Content-Type' value from request. Unable to resolve parameters.");
+            } else {
+                throw new RuntimeException("Multiple 'Content-Type' values found in request. Unable to resolve parameters.");
+            }
+        }
+
+        MediaType contentType = MediaType.parseMediaType(headerResponseTypes[0]);
+
+        HttpMessageConverter messageConverter = null;
+        for (HttpMessageConverter converter : this.messageConverters){
+            if (converter.canRead(argumentType, contentType)){
+                messageConverter = converter;
+                break;
+            }
+        }
+
+        if (messageConverter == null){
+            throw new RuntimeException("Unable to find Convertor for " + contentType.toString());
+        }
+
+
+        if (request.getContent() == null && parameterAnnotation.required()) {
+            throw new RuntimeException("The content of the request is empty while it is required.");
+        }
+        else if (request.getContent() == null && !parameterAnnotation.required()) {
+            return null;
+        }
+
+        boolean isEmpty = this.isBodyEmpty(request.getContent().getInputStream());
+        if (parameterAnnotation.required() && isEmpty) {
+           throw new RuntimeException("The body of the request is empty while it is required.");
+        }
+        else {
+            if (isEmpty) {
+                return null;
+            }
+        }
+
+        AnnotationWebScriptInputMessage inputMessage = new AnnotationWebScriptInputMessage(request);
+
+        try {
+            Object result = messageConverter.read(argumentType, inputMessage);
+            return result;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+
+        return null;
+    }
+
+
+    private boolean isBodyEmpty(InputStream inputStream){
+        try {
+            if (inputStream.available() == 0) {
+                return true;
+            }
+
+            return false;
+
+        } catch (IOException e) {
+            throw new RuntimeException("Error while checking of body is empty", e);
+        }
+
+
+    }
+
+}

--- a/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/arguments/RequestBodyArgumentResolver.java
+++ b/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/arguments/RequestBodyArgumentResolver.java
@@ -1,29 +1,24 @@
 package com.github.dynamicextensionsalfresco.webscripts.arguments;
 
+import com.github.dynamicextensionsalfresco.webscripts.MessageConverterRegistry;
 import com.github.dynamicextensionsalfresco.webscripts.messages.AnnotationWebScriptInputMessage;
 import org.springframework.extensions.webscripts.WebScriptRequest;
 import org.springframework.extensions.webscripts.WebScriptResponse;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.http.converter.xml.Jaxb2RootElementHttpMessageConverter;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PushbackInputStream;
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.List;
 
 public class RequestBodyArgumentResolver implements ArgumentResolver<Object, RequestBody> {
 
 
-    private final List<HttpMessageConverter<?>> messageConverters = new ArrayList<HttpMessageConverter<?>>();
+    private MessageConverterRegistry messageConverterRegistry;
 
-    public RequestBodyArgumentResolver() {
-        this.messageConverters.add(new MappingJackson2HttpMessageConverter());
-        this.messageConverters.add(new Jaxb2RootElementHttpMessageConverter());
+    public RequestBodyArgumentResolver(MessageConverterRegistry messageConverterRegistry) {
+        this.messageConverterRegistry = messageConverterRegistry;
     }
 
     @Override
@@ -54,13 +49,7 @@ public class RequestBodyArgumentResolver implements ArgumentResolver<Object, Req
 
         MediaType contentType = MediaType.parseMediaType(headerResponseTypes[0]);
 
-        HttpMessageConverter messageConverter = null;
-        for (HttpMessageConverter converter : this.messageConverters){
-            if (converter.canRead(argumentType, contentType)){
-                messageConverter = converter;
-                break;
-            }
-        }
+        HttpMessageConverter messageConverter = this.messageConverterRegistry.canRead(argumentType, contentType);
 
         if (messageConverter == null){
             throw new RuntimeException("Unable to find Convertor for " + contentType.toString());

--- a/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/messages/AnnotationWebScriptInputMessage.java
+++ b/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/messages/AnnotationWebScriptInputMessage.java
@@ -1,0 +1,59 @@
+package com.github.dynamicextensionsalfresco.webscripts.messages;
+
+import org.springframework.extensions.webscripts.WebScriptRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+
+public class AnnotationWebScriptInputMessage implements HttpInputMessage {
+
+    private WebScriptRequest request;
+
+    private final HttpHeadersWrapper headers;
+
+    public AnnotationWebScriptInputMessage(WebScriptRequest request) {
+        this.request = request;
+
+        this.headers = new HttpHeadersWrapper(request);
+    }
+
+    @Override
+    public InputStream getBody() throws IOException {
+        return request.getContent().getInputStream();
+    }
+
+    @Override
+    public HttpHeaders getHeaders() {
+        return this.headers;
+    }
+
+    class HttpHeadersWrapper extends HttpHeaders {
+        private final WebScriptRequest request;
+
+        public HttpHeadersWrapper(WebScriptRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public List<String> get(Object key) {
+            String[] values = request.getHeaderValues(key.toString());
+
+            return Arrays.asList(values);
+        }
+
+        @Override
+        public String getFirst(String headerName) {
+            String[] values = request.getHeaderValues(headerName);
+
+            if (values == null){
+                return null;
+            } else {
+                return values[0];
+            }
+        }
+    }
+}

--- a/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/messages/AnnotationWebScriptOutputMessage.java
+++ b/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/messages/AnnotationWebScriptOutputMessage.java
@@ -1,5 +1,7 @@
-package com.github.dynamicextensionsalfresco.webscripts;
+package com.github.dynamicextensionsalfresco.webscripts.messages;
 
+import com.github.dynamicextensionsalfresco.webscripts.AnnotationWebScriptRequest;
+import com.github.dynamicextensionsalfresco.webscripts.AnnotationWebscriptResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpOutputMessage;
@@ -16,13 +18,11 @@ import java.util.Set;
 
 public class AnnotationWebScriptOutputMessage implements HttpOutputMessage {
 
-    private final AnnotationWebScriptRequest request;
     private final AnnotationWebscriptResponse response;
 
     private final HttpHeadersWrapper headers;
 
-    public AnnotationWebScriptOutputMessage(AnnotationWebScriptRequest request, AnnotationWebscriptResponse response) {
-        this.request = request;
+    public AnnotationWebScriptOutputMessage(AnnotationWebscriptResponse response) {
         this.response = response;
 
         this.headers = new HttpHeadersWrapper(response);

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/AbstractWebScriptAnnotationsTest.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/AbstractWebScriptAnnotationsTest.java
@@ -64,4 +64,18 @@ public abstract class AbstractWebScriptAnnotationsTest {
 		handleGet(uri, new MockWebScriptRequest());
 	}
 
+
+	protected void handlePost(final String uri, final MockWebScriptRequest request, final WebScriptResponse response) {
+	    handleRequest(HttpMethod.POST, uri, request, response);
+    }
+
+    protected void handlePost(final String uri, final MockWebScriptRequest request) {
+	    handlePost(uri, request, Mockito.mock(WebScriptResponse.class));
+    }
+
+    protected void handlePost(final String uri) {
+	    handlePost(uri, new MockWebScriptRequest());
+    }
+
+
 }

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/MockWebScriptRequest.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/MockWebScriptRequest.java
@@ -230,4 +230,20 @@ class MockWebScriptRequest implements WrappingWebScriptRequest {
 		return false;
 	}
 
+
+    public void setContent(Content content) {
+        this.content = content;
+    }
+
+    public void setNext(WebScriptRequest next) {
+        this.next = next;
+    }
+
+    public void setRuntime(Runtime runtime) {
+        this.runtime = runtime;
+    }
+
+    public void setFormat(String format) {
+        this.format = format;
+    }
 }

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/MockWebscriptContent.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/MockWebscriptContent.java
@@ -1,0 +1,92 @@
+package com.github.dynamicextensionsalfresco.webscripts;
+
+import org.springframework.extensions.surf.util.Content;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+
+public class MockWebscriptContent implements Content {
+
+
+    private String content;
+    private String mimeType;
+    private String encoding;
+    private long size;
+    private InputStream inputStream;
+    private Reader reader;
+
+
+    public MockWebscriptContent() {
+
+    }
+
+    public MockWebscriptContent(String content, String mimeType, String encoding, long size, InputStream inputStream, Reader reader) {
+        this.content = content;
+        this.mimeType = mimeType;
+        this.encoding = encoding;
+        this.size = size;
+        this.inputStream = inputStream;
+        this.reader = reader;
+    }
+
+    @Override
+    public String getContent() throws IOException {
+        return this.content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    @Override
+    public String getMimetype() {
+        return this.mimeType;
+    }
+
+    public void setMimeType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    @Override
+    public String getEncoding() {
+        return this.encoding;
+    }
+
+    public void setEncoding(String encoding) {
+        this.encoding = encoding;
+    }
+
+    @Override
+    public long getSize() {
+        return this.size;
+    }
+
+    public void setSize(long size) {
+        this.size = size;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return this.inputStream;
+    }
+
+    public void setInputStream(InputStream inputStream) {
+        this.inputStream = inputStream;
+    }
+
+    public MockWebscriptContent with(InputStream inputStream) {
+        this.setInputStream(inputStream);
+
+        return this;
+    }
+
+    @Override
+    public Reader getReader() throws IOException {
+        return this.reader;
+    }
+
+    public void setReader(Reader reader) {
+        this.reader = reader;
+    }
+}

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestBodyHandler.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestBodyHandler.java
@@ -1,0 +1,23 @@
+package com.github.dynamicextensionsalfresco.webscripts;
+
+import com.github.dynamicextensionsalfresco.spring.Spied;
+import com.github.dynamicextensionsalfresco.webscripts.annotations.HttpMethod;
+import com.github.dynamicextensionsalfresco.webscripts.annotations.Uri;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Component
+@Spied
+public class RequestBodyHandler {
+
+    @Uri(value = "/requestbody/required", method = HttpMethod.POST, defaultFormat = MediaType.APPLICATION_JSON_VALUE)
+    public PersonXml requiredBody(@RequestBody(required = true) PersonXml person) {
+        return person;
+    }
+
+    @Uri(value = "/requestbody/notRequired", method = HttpMethod.POST, defaultFormat = MediaType.APPLICATION_JSON_VALUE)
+    public PersonXml notRequired(@RequestBody(required = false) PersonXml person) {
+        return person;
+    }
+}

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestBodyTest.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestBodyTest.java
@@ -1,0 +1,137 @@
+package com.github.dynamicextensionsalfresco.webscripts;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.After;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.verify;
+
+public class RequestBodyTest extends AbstractWebScriptAnnotationsTest {
+
+    @Autowired
+    private RequestBodyHandler handler;
+
+    /**
+     * This needs to be done to prevent mockito from failing.
+     * If the reset is not called, it will fail with org.mockito.exceptions.verification.TooManyActualInvocations
+     *
+     */
+    @After
+    public void tearDown() {
+        Mockito.reset(handler);
+    }
+
+
+    @Test
+    public void requiredBodyAcceptXml() throws JsonProcessingException, JAXBException {
+        JAXBContext jaxbContext = JAXBContext.newInstance(PersonXml.class);
+
+        PersonXml personXml = new PersonXml("test", "user");
+
+        Marshaller marshaller = jaxbContext.createMarshaller();
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        marshaller.marshal(personXml, outputStream);
+
+        String value = new String(outputStream.toByteArray());
+
+
+        System.out.println(value);
+
+        InputStream inputStream = new ByteArrayInputStream(value.getBytes());
+
+        MockWebScriptRequest request = new MockWebScriptRequest().header("Content-Type", "application/xml");
+        request.setContent(new MockWebscriptContent().with(inputStream));
+
+        handlePost("/requestbody/required", request);
+
+
+        verify(handler).requiredBody(argThat(new ArgumentMatcher<PersonXml>() {
+            @Override
+            public boolean matches(Object argument) {
+                return argument.equals(personXml);
+            }
+        }));
+
+    }
+
+    @Test
+    public void requiredBodyAcceptJson() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        PersonXml personXml = new PersonXml("test", "user");
+        String value = mapper.writeValueAsString(personXml);
+        System.out.println(value);
+
+        InputStream inputStream = new ByteArrayInputStream(value.getBytes());
+
+        MockWebScriptRequest request = new MockWebScriptRequest().header("Content-Type", "application/json");
+        request.setContent(new MockWebscriptContent().with(inputStream));
+
+        handlePost("/requestbody/required", request);
+
+
+        verify(handler).requiredBody(argThat(new ArgumentMatcher<PersonXml>() {
+            @Override
+            public boolean matches(Object argument) {
+                return argument.equals(personXml);
+            }
+        }));
+    }
+
+    /**
+     * When required = true, a Runtime exception is thrown.
+     */
+    @Test(expected = RuntimeException.class)
+    public void requestBodyInputStreamNullRequiredTrue() {
+        MockWebScriptRequest request = new MockWebScriptRequest().header("Content-Type", "application/json");
+        handlePost("/requestbody/required", request);
+    }
+
+    @Test
+    public void requestBodyInputStreamNullRequiredFalse() {
+        MockWebScriptRequest request = new MockWebScriptRequest().header("Content-Type", "application/json");
+        handlePost("/requestbody/notRequired", request);
+        verify(handler).notRequired(argThat(new ArgumentMatcher<PersonXml>() {
+            @Override
+            public boolean matches(Object argument) {
+                return argument == null;
+            }
+        }));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void requestBodyEmptyRequiredTrue() {
+        MockWebScriptRequest request = new MockWebScriptRequest().header("Content-Type", "application/json");
+        request.setContent(new MockWebscriptContent().with(new ByteArrayInputStream(new byte[0])));
+        handlePost("/requestbody/required", request);
+    }
+
+    @Test
+    public void requestBodyEmptyRequiredFalse() {
+        MockWebScriptRequest request = new MockWebScriptRequest().header("Content-Type", "application/json");
+        request.setContent(new MockWebscriptContent().with(new ByteArrayInputStream(new byte[0])));
+        handlePost("/requestbody/notRequired", request);
+        verify(handler).notRequired(argThat(new ArgumentMatcher<PersonXml>() {
+            @Override
+            public boolean matches(Object argument) {
+                return argument == null;
+            }
+        }));
+    }
+
+
+}

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ResponseBodyReturnValueHandler.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ResponseBodyReturnValueHandler.java
@@ -1,7 +1,6 @@
 package com.github.dynamicextensionsalfresco.webscripts;
 
 import com.github.dynamicextensionsalfresco.spring.Spied;
-import com.github.dynamicextensionsalfresco.webscripts.annotations.Header;
 import com.github.dynamicextensionsalfresco.webscripts.annotations.RequestParam;
 import com.github.dynamicextensionsalfresco.webscripts.annotations.Uri;
 import org.springframework.extensions.webscripts.WebScriptResponse;

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ResponseBodyReturnValueTest.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ResponseBodyReturnValueTest.java
@@ -51,7 +51,7 @@ public class ResponseBodyReturnValueTest extends AbstractWebScriptAnnotationsTes
 
         assertThat("Webscript response should not be empty", stream.toByteArray().length, not(0));
 
-        System.out.println(new String(stream.toByteArray()));
+//        System.out.println(new String(stream.toByteArray()));
 
         ObjectMapper mapper = new ObjectMapper();
 
@@ -78,7 +78,7 @@ public class ResponseBodyReturnValueTest extends AbstractWebScriptAnnotationsTes
 
         assertThat("Webscript response should not be empty", stream.toByteArray().length, not(0));
 
-        System.out.println(new String(stream.toByteArray()));
+//        System.out.println(new String(stream.toByteArray()));
 
         ObjectMapper mapper = new ObjectMapper();
 
@@ -101,7 +101,7 @@ public class ResponseBodyReturnValueTest extends AbstractWebScriptAnnotationsTes
                         .param("lastName", "User"),
                 new MockWebScriptResponse().setOutputStream(stream));
         assertThat("Webscript response should not be empty", stream.toByteArray().length, not(0));
-        System.out.println(new String(stream.toByteArray()));
+//        System.out.println(new String(stream.toByteArray()));
 
         JAXBContext jaxbContext = JAXBContext.newInstance(PersonXml.class);
 
@@ -151,7 +151,7 @@ public class ResponseBodyReturnValueTest extends AbstractWebScriptAnnotationsTes
                 new MockWebScriptResponse().setOutputStream(stream));
 
         assertThat("Webscript response should not be empty", stream.toByteArray().length, not(0));
-        System.out.println(new String(stream.toByteArray()));
+//        System.out.println(new String(stream.toByteArray()));
 
         JAXBContext jaxbContext = JAXBContext.newInstance(PersonXml.class);
 
@@ -177,7 +177,7 @@ public class ResponseBodyReturnValueTest extends AbstractWebScriptAnnotationsTes
                 new MockWebScriptResponse().setOutputStream(stream));
 
         assertThat("Webscript response should not be empty", stream.toByteArray().length, not(0));
-        System.out.println(new String(stream.toByteArray()));
+//        System.out.println(new String(stream.toByteArray()));
 
         ObjectMapper mapper = new ObjectMapper();
 
@@ -206,7 +206,7 @@ public class ResponseBodyReturnValueTest extends AbstractWebScriptAnnotationsTes
                 new MockWebScriptResponse().setOutputStream(stream));
 
         assertThat("Webscript response should not be empty", stream.toByteArray().length, not(0));
-        System.out.println(new String(stream.toByteArray()));
+//        System.out.println(new String(stream.toByteArray()));
 
         JAXBContext jaxbContext = JAXBContext.newInstance(PersonXml.class);
 
@@ -236,7 +236,7 @@ public class ResponseBodyReturnValueTest extends AbstractWebScriptAnnotationsTes
                 new MockWebScriptResponse().setOutputStream(stream));
 
         assertThat("Webscript response should not be empty", stream.toByteArray().length, not(0));
-        System.out.println(new String(stream.toByteArray()));
+//        System.out.println(new String(stream.toByteArray()));
 
         ObjectMapper mapper = new ObjectMapper();
 
@@ -282,7 +282,7 @@ public class ResponseBodyReturnValueTest extends AbstractWebScriptAnnotationsTes
 
         assertThat("Webscript response should not be empty", stream.toByteArray().length, not(0));
 
-        System.out.println(new String(stream.toByteArray()));
+//        System.out.println(new String(stream.toByteArray()));
 
         Assert.assertTrue(response.getHeaders().containsKey("Content-Type"));
         String actualContentType =response.getHeaders().get("Content-Type").get(0);
@@ -307,7 +307,7 @@ public class ResponseBodyReturnValueTest extends AbstractWebScriptAnnotationsTes
 
         assertThat("Webscript response should not be empty", stream.toByteArray().length, not(0));
 
-        System.out.println(new String(stream.toByteArray()));
+//        System.out.println(new String(stream.toByteArray()));
 
         Assert.assertTrue(response.getHeaders().containsKey("Content-Type"));
         String actualContentType =response.getHeaders().get("Content-Type").get(0);
@@ -333,7 +333,7 @@ public class ResponseBodyReturnValueTest extends AbstractWebScriptAnnotationsTes
 
         assertThat("Webscript response should not be empty", stream.toByteArray().length, not(0));
 
-        System.out.println(new String(stream.toByteArray()));
+//        System.out.println(new String(stream.toByteArray()));
 
         Assert.assertTrue(response.getHeaders().containsKey("Content-Type"));
         String actualContentType =response.getHeaders().get("Content-Type").get(0);
@@ -357,7 +357,7 @@ public class ResponseBodyReturnValueTest extends AbstractWebScriptAnnotationsTes
 
         assertThat("Webscript response should not be empty", stream.toByteArray().length, not(0));
 
-        System.out.println(new String(stream.toByteArray()));
+//        System.out.println(new String(stream.toByteArray()));
 
         Assert.assertTrue(response.getHeaders().containsKey("Test"));
         String value =response.getHeaders().get("Test").get(0);

--- a/annotations-runtime/src/test/resources/com/github/dynamicextensionsalfresco/webscripts/webscript-integration-test-context.xml
+++ b/annotations-runtime/src/test/resources/com/github/dynamicextensionsalfresco/webscripts/webscript-integration-test-context.xml
@@ -28,7 +28,10 @@ http://www.springframework.org/schema/util/spring-util-3.0.xsd">
 				<property name="namespacePrefixResolver" ref="namespacePrefixResolver" />
 			</bean>
 		</property>
-	</bean>
+        <property name="messageConverterRegistry" ref="webscripts.MessageConverterRegistry" />
+    </bean>
+
+	<bean id="webscripts.MessageConverterRegistry" class="com.github.dynamicextensionsalfresco.webscripts.MessageConverterRegistry" />
 
 	<bean id="namespacePrefixResolver" class="com.github.dynamicextensionsalfresco.spring.MockFactoryBean">
 		<property name="class" value="org.alfresco.service.namespace.NamespacePrefixResolver" />

--- a/annotations/src/main/java/com/github/dynamicextensionsalfresco/webscripts/annotations/MessageConverter.java
+++ b/annotations/src/main/java/com/github/dynamicextensionsalfresco/webscripts/annotations/MessageConverter.java
@@ -1,0 +1,11 @@
+package com.github.dynamicextensionsalfresco.webscripts.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MessageConverter {
+}

--- a/blueprint-integration/src/main/kotlin/com/github/dynamicextensionsalfresco/blueprint/DynamicExtensionsApplicationContext.kt
+++ b/blueprint-integration/src/main/kotlin/com/github/dynamicextensionsalfresco/blueprint/DynamicExtensionsApplicationContext.kt
@@ -21,6 +21,7 @@ import com.github.dynamicextensionsalfresco.resources.ResourceHelper
 import com.github.dynamicextensionsalfresco.web.WebResourcesRegistrar
 import com.github.dynamicextensionsalfresco.webscripts.AnnotationWebScriptBuilder
 import com.github.dynamicextensionsalfresco.webscripts.AnnotationWebScriptRegistrar
+import com.github.dynamicextensionsalfresco.webscripts.MessageConverterRegistry
 import com.github.dynamicextensionsalfresco.webscripts.WebScriptUriRegistry
 import com.github.dynamicextensionsalfresco.webscripts.arguments.HandlerMethodArgumentsResolver
 import com.github.dynamicextensionsalfresco.webscripts.arguments.StringValueConverter
@@ -250,13 +251,20 @@ class DynamicExtensionsApplicationContext(configurationLocations: Array<String>?
         beanFactory.bean(BeanNames.STRING_VALUE_CONVERTER, StringValueConverter::class.java) {
             addPropertyValue("namespacePrefixResolver", getService(NamespacePrefixResolver::class.java))
         }
+
+        beanFactory.bean(BeanNames.MESSAGE_CONVERTER_REGISTER, MessageConverterRegistry::class.java)
+
         beanFactory.bean(BeanNames.HANDLER_METHOD_ARGUMENTS_RESOLVER, HandlerMethodArgumentsResolver::class.java) {
             addPropertyReference("stringValueConverter", BeanNames.STRING_VALUE_CONVERTER.id())
+            addPropertyReference("messageConverterRegistry", BeanNames.MESSAGE_CONVERTER_REGISTER.id())
             addPropertyValue("bundleContext", bundleContext)
             setInitMethodName("initializeArgumentResolvers")
         }
+
+
         beanFactory.bean(BeanNames.ANNOTATION_BASED_WEB_SCRIPT_BUILDER, AnnotationWebScriptBuilder::class.java) {
-            addPropertyReference("handlerMethodArgumentsResolver",BeanNames.HANDLER_METHOD_ARGUMENTS_RESOLVER.id());
+            addPropertyReference("handlerMethodArgumentsResolver",BeanNames.HANDLER_METHOD_ARGUMENTS_RESOLVER.id())
+            addPropertyReference("messageConverterRegistry", BeanNames.MESSAGE_CONVERTER_REGISTER.id())
         }
         beanFactory.bean(BeanNames.ANNOTATION_BASED_WEB_SCRIPT_REGISTRAR, AnnotationWebScriptRegistrar::class.java) {
             addPropertyReference("annotationBasedWebScriptBuilder", BeanNames.ANNOTATION_BASED_WEB_SCRIPT_BUILDER.id())


### PR DESCRIPTION
Add support to use @RequestBody annotation in your webscript. When using this, the body of your request is automaticaly deserialized. The deserializer is automatically selected depending on you 'Content-Type' header.