### PR TITLE
Made requestBody  work for alfresco 4.2

### DIFF
--- a/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/arguments/RequestBodyArgumentResolver.java
+++ b/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/webscripts/arguments/RequestBodyArgumentResolver.java
@@ -56,22 +56,28 @@ public class RequestBodyArgumentResolver implements ArgumentResolver<Object, Req
         }
 
 
-        if (request.getContent() == null && parameterAnnotation.required()) {
+        // Because the required parameter is not available in the spring version that ships with Alfresco 4.2,
+        // we will assume that it is always true.
+        // TODO reinsert check for required parameter when alfresco 4.2 is deprecated.
+
+        //if (request.getContent() == null && parameterAnnotation.required()) {
+        if (request.getContent() == null) {
             throw new RuntimeException("The content of the request is empty while it is required.");
         }
-        else if (request.getContent() == null && !parameterAnnotation.required()) {
-            return null;
-        }
+        //else if (request.getContent() == null && !parameterAnnotation.required()) {
+//            return null;
+//        }
 
         boolean isEmpty = this.isBodyEmpty(request.getContent().getInputStream());
-        if (parameterAnnotation.required() && isEmpty) {
+        //if (parameterAnnotation.required() && isEmpty) {
+        if (isEmpty) {
            throw new RuntimeException("The body of the request is empty while it is required.");
         }
-        else {
-            if (isEmpty) {
-                return null;
-            }
-        }
+//        else {
+//            if (isEmpty) {
+//                return null;
+//            }
+//        }
 
         AnnotationWebScriptInputMessage inputMessage = new AnnotationWebScriptInputMessage(request);
 

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestBodyTest.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestBodyTest.java
@@ -3,6 +3,7 @@ package com.github.dynamicextensionsalfresco.webscripts;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
@@ -102,6 +103,7 @@ public class RequestBodyTest extends AbstractWebScriptAnnotationsTest {
     }
 
     @Test
+    @Ignore("The required parameter is not available in the Alfresco 4.2 spring version.")
     public void requestBodyInputStreamNullRequiredFalse() {
         MockWebScriptRequest request = new MockWebScriptRequest().header("Content-Type", "application/json");
         handlePost("/requestbody/notRequired", request);
@@ -121,6 +123,7 @@ public class RequestBodyTest extends AbstractWebScriptAnnotationsTest {
     }
 
     @Test
+    @Ignore("The required parameter is not available in the Alfresco 4.2 spring version.")
     public void requestBodyEmptyRequiredFalse() {
         MockWebScriptRequest request = new MockWebScriptRequest().header("Content-Type", "application/json");
         request.setContent(new MockWebscriptContent().with(new ByteArrayInputStream(new byte[0])));


### PR DESCRIPTION
fix for issue #160 
The message converter registry will now add default converters if there respective classes are present in the classpath.