### PR TITLE
Fix Reflected XSS through maliciously formed URLs

### DIFF
--- a/webscripts/src/main/java/com/github/dynamicextensionsalfresco/webscripts/support/AbstractBundleResourceHandler.java
+++ b/webscripts/src/main/java/com/github/dynamicextensionsalfresco/webscripts/support/AbstractBundleResourceHandler.java
@@ -11,6 +11,7 @@ import org.springframework.extensions.webscripts.WebScriptRequest;
 import org.springframework.extensions.webscripts.WebScriptResponse;
 import org.springframework.util.Assert;
 import org.springframework.util.FileCopyUtils;
+import org.springframework.web.util.HtmlUtils;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletResponse;
@@ -126,8 +127,9 @@ public abstract class AbstractBundleResourceHandler {
 
 	protected void handleResourceNotFound(final String path, final WebScriptResponse response) throws IOException {
 		response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+		response.setContentType("text/html");
 		final Writer out = response.getWriter();
-		out.write(String.format("Could not find resource at path '%s'.", path));
+		out.write(String.format("<!doctype html><head><title>Not found</title></head><body>Could not find resource at path '%s'.</body></html>", HtmlUtils.htmlEscape(path)));
 		out.close();
 	}
 


### PR DESCRIPTION
Reflected XSS is possible in extensions that use the `com.github.dynamicextensionsalfresco.webscripts.support.AbstractBundleResourceHandler.handleResourceNotFound()` method to trigger an error message when a resource is not found.

## Description

Example:
```java
@Component
@WebScript(families="xss")
@Transaction(TransactionType.NONE)
public class XSSResourceWebScript extends AbstractBundleResourceHandler {

    private final String packagePath;

    public FinderResourceWebScript() {
        packagePath = this.getClass().getPackage().getName().replace('.', '/');
    
    @Uri(value = "/resources/{path}", formatStyle = FormatStyle.ARGUMENT)
    public void handleResources(@UriVariable final String path, final WebScriptResponse response, WebScriptRequest request) throws Exception {

        final URL resource = getBundleContext().getBundle().getEntry(path);
        if (resource != null) {
            sendResource(request, response, resource);
        } else {
            handleResourceNotFound(path, response);
        }
}
```

Visiting `/alfresco/s/resources/<script>alert('XSS');</script>index.html` shows a javascript alert window.

## Related Issue

Private
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Tested that it remedies a specific XSS payload in IE11, Edge 15, Chrome latest, Firefox latest on Windows 10.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
