### PR TITLE
Update compile dependencies to compileOnly in the gradle plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Version template:
 # Dynamic Extensions For Alfresco Changelog
 
 ## [UNRELEASED]
+### Fixed
+* [#180](https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/180) Use compileOnly dependencies in the gradle plugin
 
 ## [1.7.4] - 2018-03-08
 ### Added

--- a/gradle-plugin/src/main/groovy/com/github/dynamicextensionsalfresco/gradle/DynamicExtensionPlugin.groovy
+++ b/gradle-plugin/src/main/groovy/com/github/dynamicextensionsalfresco/gradle/DynamicExtensionPlugin.groovy
@@ -49,15 +49,15 @@ class DynamicExtensionPlugin implements Plugin<Project> {
 			version: project.alfrescoDynamicExtensions.versions.spring
 		]
 		project.dependencies {
-			compile ("org.springframework.extensions.surf:spring-webscripts:${surf.version}") { transitive = false }
-			compile ("org.springframework.extensions.surf:spring-surf-core:${surf.version}") { transitive = false }
-			compile ("eu.xenit.de:annotations:${dynamicExtensions.version}") { transitive = false }
-			compile ("eu.xenit.de:annotations-runtime:${dynamicExtensions.version}") { transitive = false }
-            compile ("eu.xenit.de:webscripts:${dynamicExtensions.version}") { transitive = false }
+			compileOnly ("org.springframework.extensions.surf:spring-webscripts:${surf.version}") { transitive = false }
+			compileOnly ("org.springframework.extensions.surf:spring-surf-core:${surf.version}") { transitive = false }
+			compileOnly ("eu.xenit.de:annotations:${dynamicExtensions.version}") { transitive = false }
+			compileOnly ("eu.xenit.de:annotations-runtime:${dynamicExtensions.version}") { transitive = false }
+                        compileOnly ("eu.xenit.de:webscripts:${dynamicExtensions.version}") { transitive = false }
 			// Since Spring is so fundamental, this is the one dependency we leave as transitive.
-			compile ("org.springframework:spring-context:${spring.version}")
+			compileOnly ("org.springframework:spring-context:${spring.version}")
 			// JSR-250 API contains the @Resource annotation for referencing dependencies by name.
-			compile ('javax.annotation:jsr250-api:1.0') { transitive = false }
+			compileOnly ('javax.annotation:jsr250-api:1.0') { transitive = false }
 		}
 	}
 


### PR DESCRIPTION
## Description
Compile dependencies get pulled in and bundled in the compiled jar, but these dependencies are already provided by dynamic extensions, so they should not be bundled.
Currently, we use transitive = false everywhere to avoid bundling all these jars, but compileOnly dependencies are a better option, because then they are not included in the runtime dependencies

## Related Issue

#180 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the changelog.
