### PR TITLE
Removed hard coded static webscript url

### DIFF
--- a/annotations-runtime/src/main/kotlin/com/github/dynamicextensionsalfresco/web/ResourceWebscript.kt
+++ b/annotations-runtime/src/main/kotlin/com/github/dynamicextensionsalfresco/web/ResourceWebscript.kt
@@ -15,7 +15,7 @@ import javax.servlet.http.HttpServletResponse
  * @author Laurent Van der Linden
  */
 public class ResourceWebscript(private val bundleContext: BundleContext) : WebScript, AbstractBundleResourceHandler() {
-    private val module = "alfresco-dynamic-extensions-repo-control-panel";
+    private val module = bundleContext.bundle.symbolicName.replace(".", "-").toLowerCase();
 
     init {
         initContentTypes()

--- a/control-panel/src/main/resources/com/github/dynamicextensionsalfresco/controlpanel/templates/html-macros.inc.ftl
+++ b/control-panel/src/main/resources/com/github/dynamicextensionsalfresco/controlpanel/templates/html-macros.inc.ftl
@@ -7,7 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <base href="${url.serviceContext}/dynamic-extensions/"/>
-    <#assign resourceBase = "${url.serviceContext}/alfresco-dynamic-extensions-repo-control-panel/web/" />
+    <#assign resourceBase = "${url.serviceContext}/eu-xenit-de-control-panel/web/" />
 
     <link rel="stylesheet" type="text/css" href="${resourceBase}stylesheets/bootstrap/css/bootstrap.min.css"/>
     <link rel="stylesheet" type="text/css" href="${resourceBase}stylesheets/bootstrap/css/bootstrap-responsive.min.css"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix for issue #181, static urls should take the name of the bundle now

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
issue #181

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The urls were hardcoded for `alfresco-dynamic-extensions-repo-control-panel`, changed it to bundle name.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manualy by me.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the changelog.
