### PR TITLE
Bump version number to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Version template:
  -->
 # Dynamic Extensions For Alfresco Changelog
 
-## [1.8.0] - UNRELEASED
+## [2.0.0] - UNRELEASED
 ### Changed
 * Build process refactored to build and compile for specific Alfresco versions
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ nexusStaging {
 
 allprojects {
     group = 'eu.xenit.de'
-    version = '1.8.0-SNAPSHOT'
+    version = '2.0.0-SNAPSHOT'
     
     apply plugin: 'idea'
     apply plugin: 'eclipse'

--- a/gradle-plugin/src/main/java/com/github/dynamicextensionsalfresco/gradle/configuration/Versions.java
+++ b/gradle-plugin/src/main/java/com/github/dynamicextensionsalfresco/gradle/configuration/Versions.java
@@ -6,7 +6,7 @@ package com.github.dynamicextensionsalfresco.gradle.configuration;
  */
 
 public class Versions {
-	String dynamicExtensions = "1.8.0-SNAPSHOT";
+	String dynamicExtensions = "2.0.0-SNAPSHOT";
 	
 	String surf = "5.0.d";
 


### PR DESCRIPTION
In order to provide support for multiple Alfresco versions, we are currently identifying the public API of Dynamic Extensions and splitting this from the runtime artifacts.
To clearly split the public API & runtime, we have some breaking changes ahead. 