### PR TITLE
Include Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,9 +13,21 @@ pipeline {
             }
         }
 
+        stage("Clean") {
+            when {
+                anyOf {
+                    branch "master*"
+                    changeRequest target: 'master*', comparator: 'GLOB'
+                }
+            }
+            steps {
+                sh "./gradlew clean"
+            }
+        }
+
         stage("Assemble") {
             steps {
-                sh "./gradlew clean assemble"
+                sh "./gradlew assemble"
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,71 @@
+pipeline {
+    agent any
+
+    stages {
+
+        stage('Setting version') {
+            steps {
+                sh "./gradlew makeVersionFile"
+                script {
+                    def version = readFile('build/version')
+                    currentBuild.displayName = "${version} (#${env.BUILD_NUMBER})"
+                }
+            }
+        }
+
+        stage("Assemble") {
+            steps {
+                sh "./gradlew clean assemble"
+            }
+        }
+
+        stage("Test") {
+            steps {
+                sh "./gradlew test"
+            }
+        }
+
+        stage("Integration Test") {
+            steps {
+                sh "./gradlew integrationTest"
+            }
+        }
+
+        stage('Publish Jars & Amps') {
+            when {
+                anyOf {
+                    branch "master*"
+                }
+            }
+            environment {
+                SONNATYPE_CREDENTIALS = credentials('sonatype')
+                GPGPASSPHRASE = credentials('gpgpassphrase')
+            }
+            steps {
+                script {
+                    sh "./gradlew uploadArchives -Pde_publish_username=${SONNATYPE_CREDENTIALS_USR} -Pde_publish_password=${SONNATYPE_CREDENTIALS_PSW} -PkeyId=DF8285F0 -Ppassword=${GPGPASSPHRASE} -PsecretKeyRingFile=/var/jenkins_home/secring.gpg"
+                }
+            }
+        }
+    }
+
+
+    post {
+        aborted {
+            sh "./gradlew composeDownForced"
+        }
+        failure {
+            sh "./gradlew composeDownForced"
+        }
+        success {
+            archiveArtifacts artifacts: '**/build/amps/*.amp'
+        }
+        always {
+            script {
+                junit '**/build/test-results/**/*.xml'
+            }
+        }
+    }
+}
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -266,3 +266,16 @@ configure((
 configure([project(':gradle-plugin'), project(':annotations')], allSubProjectsConfig)
 
 defaultTasks 'build'
+
+ext.versionFile = "${project.buildDir}/version"
+
+task makeVersionFile {
+    group "build"
+    description "Make a file containing the version"
+    outputs.file versionFile
+
+    doLast {
+        file(versionFile).write version
+        println "Version ${version}"
+    }
+}


### PR DESCRIPTION
`Jenkinsfile` for internal Xenit used for publishing the artifacts. 
The idea is that this internal build can later also be used for integration testing against Alfresco Enterprise versions.