### PR TITLE
Java 8 source- and target-compatiblity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,9 +155,11 @@ def allSubProjectsConfig = {
 
     [compileJava, compileTestJava, javadoc]*.options*.encoding = 'UTF-8'
 
-    compileJava {
-        sourceCompatibility = 1.7
-        targetCompatibility = 1.7
+    tasks.withType(JavaCompile) {
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
+
+        options.encoding = "UTF-8"
         options.compilerArgs << '-Xlint:unchecked'
     }
 

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -7,8 +7,8 @@ dependencies {
 }
 
 compileGroovy {
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 }
 
 defaultTasks 'build'


### PR DESCRIPTION
Architectural decision to drop support for Java 7.