### PR TITLE
Maven publish plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
             }
             steps {
                 script {
-                    sh "./gradlew uploadArchives -Pde_publish_username=${SONNATYPE_CREDENTIALS_USR} -Pde_publish_password=${SONNATYPE_CREDENTIALS_PSW} -PkeyId=DF8285F0 -Ppassword=${GPGPASSPHRASE} -PsecretKeyRingFile=/var/jenkins_home/secring.gpg"
+                    sh "./gradlew publish -Pde_publish_username=${SONNATYPE_CREDENTIALS_USR} -Pde_publish_password=${SONNATYPE_CREDENTIALS_PSW} -PkeyId=DF8285F0 -Ppassword=${GPGPASSPHRASE} -PsecretKeyRingFile=/var/jenkins_home/secring.gpg"
                 }
             }
         }

--- a/alfresco-dynamic-extensions-repo/build.gradle
+++ b/alfresco-dynamic-extensions-repo/build.gradle
@@ -4,13 +4,14 @@ subprojects {
     configurations {
         ampArtifact
         ampLib
-        compile.extendsFrom(ampLib)
+        compileOnly.extendsFrom(ampLib)
+        testCompile.extendsFrom(compileOnly)
         blueprint
         bundles
     }
 
     dependencies {
-        implementation "${project.ext.alfrescoBom}"
+        compileOnly "${project.ext.alfrescoBom}"
 
         ampLib(project(":alfresco-integration:alfresco-integration-${project.ext.simpleAlfrescoVersion}")) {
             transitive = false

--- a/alfresco-dynamic-extensions-repo/build.gradle
+++ b/alfresco-dynamic-extensions-repo/build.gradle
@@ -98,11 +98,8 @@ subprojects {
     }
 
     artifacts {
-        archives sourceJar, javadocJar
         ampArtifact amp
     }
 
     build.dependsOn("amp")
-
-    uploadArchives.dependsOn("amp")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ def allSubProjectsConfig = {
 
     apply plugin: 'java'
     apply plugin: 'jacoco'
-    apply plugin: 'maven'
+    apply plugin: 'maven-publish'
     apply plugin: 'signing'
 
     task sourceJar(type: Jar) {
@@ -77,77 +77,60 @@ def allSubProjectsConfig = {
     }
 
     artifacts {
-        archives sourceJar, javadocJar
+        archives jar
+        archives sourceJar
+        archives javadocJar
     }
 
-    uploadArchives {
-        repositories {
-            mavenDeployer {
-                signing {
-                    required { false }
-                    sign configurations.archives
-                }
-                beforeDeployment {
-                    MavenDeployment deployment ->
+    signing {
+        required { !version.endsWith('SNAPSHOT') && gradle.taskGraph.hasTask("publish") }
+        sign configurations.archives
+    }
 
-                        signing.signPom(deployment)
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                from components.java
+                artifact sourceJar
+                artifact javadocJar
 
-                }
-
-                repository(url: project.hasProperty('de_publish_url') ? project.de_publish_url : "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                    authentication(userName: project.hasProperty('de_publish_username') ? project.de_publish_username : '', password: project.hasProperty('de_publish_password') ? project.de_publish_password : '')
-                }
-
-                snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                    authentication(userName: project.hasProperty('de_publish_username') ? project.de_publish_username : '', password: project.hasProperty('de_publish_password') ? project.de_publish_password : '')
+                afterEvaluate {
+                    if (!project.getTasksByName('amp', false).isEmpty()) {
+                        artifact amp
+                    }
                 }
 
-                pom.project {
-                    url 'https://github.com/xenit-eu/dynamic-extensions-for-alfresco'
-                    name "dynamic-extensions-for-alfresco-" + project.name
-                    description "Adds an OSGi container to alfresco repository supporting dynamic code reloading, " +
+                pom {
+                    url = 'https://github.com/xenit-eu/dynamic-extensions-for-alfresco'
+                    name = "dynamic-extensions-for-alfresco-" + project.name
+                    description = "Adds an OSGi container to alfresco repository supporting dynamic code reloading, " +
                             "classpath isolation and a bunch of other useful features"
 
                     scm {
-                        connection 'scm:git:git@github.com:xenit-eu/dynamic-extensions-for-alfresco.git'
-                        developerConnection 'scm:git:git@github.com:xenit-eu/dynamic-extensions-for-alfresco.git'
-                        url 'https://github.com/xenit-eu/dynamic-extensions-for-alfresco.git'
+                        connection = 'scm:git:git@github.com:xenit-eu/dynamic-extensions-for-alfresco.git'
+                        developerConnection = 'scm:git:git@github.com:xenit-eu/dynamic-extensions-for-alfresco.git'
+                        url = 'https://github.com/xenit-eu/dynamic-extensions-for-alfresco.git'
                     }
 
                     licenses {
                         license {
-                            name 'The Apache License, Version 2.0'
-                            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                            name = 'The Apache License, Version 2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                         }
                     }
+                }
+            }
+        }
 
-                    developers {
-                        developer {
-                            id "laurentvdl"
-                            name "Laurent Van der Linden"
-                            roles {
-                                role "Founder"
-                                role "Architect"
-                            }
-                        }
-                        developer {
-                            id 'stanmine'
-                            name 'Stan Mine'
-                            email 'stan.mine@xenit.eu'
-                            roles {
-                                role "Architect"
-                                role "Developer"
-                            }
-                        }
-                        developer {
-                            id 'yregaieg'
-                            name 'Younes Regaieg'
-                            email 'younes.regaieg@xenit.eu'
-                            roles {
-                                role "Contributor"
-                            }
-                        }
-                    }
+        repositories {
+            maven {
+                def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+
+                credentials {
+                    username = project.hasProperty('de_publish_username') ? project.de_publish_username : ''
+                    password = project.hasProperty('de_publish_password') ? project.de_publish_password : ''
                 }
             }
         }
@@ -189,10 +172,8 @@ def allSubProjectsConfig = {
         bndVersion = '2.4.1'
     }
 
-
-
     gradle.taskGraph.whenReady { graph ->
-        if (graph.hasTask(uploadArchives)) {
+        if (graph.hasTask(publish)) {
             if (!project.hasProperty('keyId') || !project.hasProperty('secretKeyRingFile') || !project.hasProperty('password')) {
                 throw new GradleException('You need to provide signing params in order to sign artifacts')
             }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 import eu.xenit.dynamicextensionsalfresco.Versions
 
 enableFeaturePreview("IMPROVED_POM_SUPPORT")
+enableFeaturePreview('STABLE_PUBLISHING')
 
 include 'annotations'
 include 'webscripts'


### PR DESCRIPTION
During development, we encountered some issues with the pom generated by the Gradle `maven` plugin. With this PR, we are moving to the 'standard' `maven-publish` plugin. 

FYI, from the Gradle documentation:
https://docs.gradle.org/current/userguide/maven_plugin.html

> This chapter describes deploying artifacts to Maven repositories using the original publishing mechanism available in Gradle 1.0: in Gradle 1.3 a new mechanism for publishing was introduced. This new mechanism introduces some new concepts and features that make Gradle publishing even more powerful and is now the preferred option for publishing artifacts.