### PR TITLE
Fixes @ScheduledQuartzJob with cluster=true

### DIFF
--- a/annotations-runtime/annotations-runtime-50/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrar.java
+++ b/annotations-runtime/annotations-runtime-50/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrar.java
@@ -5,6 +5,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Properties;
+import org.alfresco.repo.lock.JobLockService;
 import org.alfresco.schedule.AbstractScheduledLockedJob;
 import org.quartz.CronTrigger;
 import org.quartz.Job;
@@ -17,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.util.Assert;
@@ -28,42 +30,62 @@ public class QuartzJobRegistrar implements ApplicationContextAware, Initializing
     private Logger logger = LoggerFactory.getLogger(QuartzJobRegistrar.class);
 
     public final static String BEAN_ID="bean";
+    public static final String JOB_LOCK_SERVICE = "jobLockService";
+
+    private ArrayList<ScheduledQuartzJob> registeredJobs = new ArrayList<ScheduledQuartzJob>();
 
     @Autowired
     protected Scheduler scheduler;
-    private ArrayList<ScheduledQuartzJob> registeredJobs = new ArrayList<ScheduledQuartzJob>();
+
+    @Autowired
+    protected JobLockService jobLockService;
+
+    @Autowired
+    @Qualifier("global-properties")
+    protected Properties globalProperties = new Properties();
 
     private ApplicationContext applicationContext;
 
     @Override
-    public void afterPropertiesSet() throws ParseException, SchedulerException {
+    public void afterPropertiesSet() {
+        this.registerScheduledQuartzJobAnnotatedBeans();
+    }
+
+    public void registerScheduledQuartzJobAnnotatedBeans() {
         Map<String, Object> scheduledBeans = applicationContext.getBeansWithAnnotation(ScheduledQuartzJob.class);
         for (Map.Entry entry : scheduledBeans.entrySet()) {
             Object bean = entry.getValue();
-            Assert.isInstanceOf(Job.class, bean, "annotated Quartz job classes should implement org.quartz.Job");
-
-            ScheduledQuartzJob annotation = bean.getClass().getAnnotation(ScheduledQuartzJob.class);
-
             try {
-                String cron = applicationContext.getBean("global-properties", Properties.class).getProperty(annotation.cronProp(), annotation.cron());
-                CronTrigger trigger = new CronTrigger(annotation.name(), annotation.group(), cron);
-                JobDetail jobDetail = new JobDetail(annotation.name(), annotation.group(), annotation.cluster() ? AbstractScheduledLockedJob.class : GenericQuartzJob.class);
-                JobDataMap map = new JobDataMap();
-                map.put(BEAN_ID, bean);
-                jobDetail.setJobDataMap(map);
-                scheduler.scheduleJob(jobDetail, trigger);
-
-                registeredJobs.add(annotation);
-
-                logger.debug("scheduled job " + annotation.name() + " from group " + annotation.group() + " using cron " + annotation.cron());
+                this.registerJob(bean);
             } catch (Exception e) {
-                logger.error("failed to register job " + annotation.name() + " using cron " + annotation.group(), e);
+                logger.error("Failed to register job: ", e);
             }
         }
     }
 
+    public void registerJob(Object bean) throws ParseException, SchedulerException {
+        Assert.isInstanceOf(Job.class, bean, "annotated Quartz job classes should implement org.quartz.Job");
+
+        ScheduledQuartzJob annotation = bean.getClass().getAnnotation(ScheduledQuartzJob.class);
+
+        String cron = applicationContext.getBean("global-properties", Properties.class).getProperty(annotation.cronProp(), annotation.cron());
+        CronTrigger trigger = new CronTrigger(annotation.name(), annotation.group(), cron);
+        JobDetail jobDetail = new JobDetail(annotation.name(), annotation.group(), annotation.cluster() ? ClusterLockedJob.class : GenericQuartzJob.class);
+
+        JobDataMap map = new JobDataMap();
+        map.put(BEAN_ID, bean);
+        map.put(JOB_LOCK_SERVICE, this.jobLockService);
+
+        jobDetail.setJobDataMap(map);
+        scheduler.scheduleJob(jobDetail, trigger);
+
+        registeredJobs.add(annotation);
+
+        logger.debug("scheduled job " + annotation.name() + " from group " + annotation.group() + " using cron " + annotation.cron());
+    }
+
     @Override
-    public void destroy() throws SchedulerException {
+    public void destroy() {
         for (ScheduledQuartzJob job : registeredJobs) {
             try {
                 scheduler.unscheduleJob(job.name(), job.group());
@@ -76,6 +98,14 @@ public class QuartzJobRegistrar implements ApplicationContextAware, Initializing
 
     public void setApplicationContext(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
+    }
+
+    public void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public void setJobLockService(JobLockService jobLockService) {
+        this.jobLockService = jobLockService;
     }
 
 }

--- a/annotations-runtime/annotations-runtime-50/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrar.java
+++ b/annotations-runtime/annotations-runtime-50/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrar.java
@@ -75,6 +75,7 @@ public class QuartzJobRegistrar implements ApplicationContextAware, Initializing
         JobDataMap map = new JobDataMap();
         map.put(BEAN_ID, bean);
         map.put(JOB_LOCK_SERVICE, this.jobLockService);
+        map.put("name", trigger.getKey().toString());
 
         jobDetail.setJobDataMap(map);
         scheduler.scheduleJob(jobDetail, trigger);

--- a/annotations-runtime/annotations-runtime-51/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrar.java
+++ b/annotations-runtime/annotations-runtime-51/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrar.java
@@ -5,6 +5,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Properties;
+import org.alfresco.repo.lock.JobLockService;
 import org.alfresco.schedule.AbstractScheduledLockedJob;
 import org.quartz.CronTrigger;
 import org.quartz.Job;
@@ -17,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.util.Assert;
@@ -28,42 +30,62 @@ public class QuartzJobRegistrar implements ApplicationContextAware, Initializing
     private Logger logger = LoggerFactory.getLogger(QuartzJobRegistrar.class);
 
     public final static String BEAN_ID="bean";
+    public static final String JOB_LOCK_SERVICE = "jobLockService";
+
+    private ArrayList<ScheduledQuartzJob> registeredJobs = new ArrayList<ScheduledQuartzJob>();
 
     @Autowired
     protected Scheduler scheduler;
-    private ArrayList<ScheduledQuartzJob> registeredJobs = new ArrayList<ScheduledQuartzJob>();
+
+    @Autowired
+    protected JobLockService jobLockService;
+
+    @Autowired
+    @Qualifier("global-properties")
+    protected Properties globalProperties = new Properties();
 
     private ApplicationContext applicationContext;
 
     @Override
-    public void afterPropertiesSet() throws ParseException, SchedulerException {
+    public void afterPropertiesSet() {
+        this.registerScheduledQuartzJobAnnotatedBeans();
+    }
+
+    public void registerScheduledQuartzJobAnnotatedBeans() {
         Map<String, Object> scheduledBeans = applicationContext.getBeansWithAnnotation(ScheduledQuartzJob.class);
         for (Map.Entry entry : scheduledBeans.entrySet()) {
             Object bean = entry.getValue();
-            Assert.isInstanceOf(Job.class, bean, "annotated Quartz job classes should implement org.quartz.Job");
-
-            ScheduledQuartzJob annotation = bean.getClass().getAnnotation(ScheduledQuartzJob.class);
-
             try {
-                String cron = applicationContext.getBean("global-properties", Properties.class).getProperty(annotation.cronProp(), annotation.cron());
-                CronTrigger trigger = new CronTrigger(annotation.name(), annotation.group(), cron);
-                JobDetail jobDetail = new JobDetail(annotation.name(), annotation.group(), annotation.cluster() ? AbstractScheduledLockedJob.class : GenericQuartzJob.class);
-                JobDataMap map = new JobDataMap();
-                map.put(BEAN_ID, bean);
-                jobDetail.setJobDataMap(map);
-                scheduler.scheduleJob(jobDetail, trigger);
-
-                registeredJobs.add(annotation);
-
-                logger.debug("scheduled job " + annotation.name() + " from group " + annotation.group() + " using cron " + annotation.cron());
+                this.registerJob(bean);
             } catch (Exception e) {
-                logger.error("failed to register job " + annotation.name() + " using cron " + annotation.group(), e);
+                logger.error("Failed to register job: ", e);
             }
         }
     }
 
+    public void registerJob(Object bean) throws ParseException, SchedulerException {
+        Assert.isInstanceOf(Job.class, bean, "annotated Quartz job classes should implement org.quartz.Job");
+
+        ScheduledQuartzJob annotation = bean.getClass().getAnnotation(ScheduledQuartzJob.class);
+
+        String cron = applicationContext.getBean("global-properties", Properties.class).getProperty(annotation.cronProp(), annotation.cron());
+        CronTrigger trigger = new CronTrigger(annotation.name(), annotation.group(), cron);
+        JobDetail jobDetail = new JobDetail(annotation.name(), annotation.group(), annotation.cluster() ? ClusterLockedJob.class : GenericQuartzJob.class);
+
+        JobDataMap map = new JobDataMap();
+        map.put(BEAN_ID, bean);
+        map.put(JOB_LOCK_SERVICE, this.jobLockService);
+
+        jobDetail.setJobDataMap(map);
+        scheduler.scheduleJob(jobDetail, trigger);
+
+        registeredJobs.add(annotation);
+
+        logger.debug("scheduled job " + annotation.name() + " from group " + annotation.group() + " using cron " + annotation.cron());
+    }
+
     @Override
-    public void destroy() throws SchedulerException {
+    public void destroy() {
         for (ScheduledQuartzJob job : registeredJobs) {
             try {
                 scheduler.unscheduleJob(job.name(), job.group());
@@ -76,6 +98,14 @@ public class QuartzJobRegistrar implements ApplicationContextAware, Initializing
 
     public void setApplicationContext(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
+    }
+
+    public void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public void setJobLockService(JobLockService jobLockService) {
+        this.jobLockService = jobLockService;
     }
 
 }

--- a/annotations-runtime/annotations-runtime-51/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrar.java
+++ b/annotations-runtime/annotations-runtime-51/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrar.java
@@ -75,6 +75,7 @@ public class QuartzJobRegistrar implements ApplicationContextAware, Initializing
         JobDataMap map = new JobDataMap();
         map.put(BEAN_ID, bean);
         map.put(JOB_LOCK_SERVICE, this.jobLockService);
+        map.put("name", trigger.getKey().toString());
 
         jobDetail.setJobDataMap(map);
         scheduler.scheduleJob(jobDetail, trigger);

--- a/annotations-runtime/annotations-runtime-52/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrar.java
+++ b/annotations-runtime/annotations-runtime-52/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrar.java
@@ -5,6 +5,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Properties;
+import org.alfresco.repo.lock.JobLockService;
 import org.alfresco.schedule.AbstractScheduledLockedJob;
 import org.quartz.CronTrigger;
 import org.quartz.Job;
@@ -17,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.util.Assert;
@@ -28,42 +30,62 @@ public class QuartzJobRegistrar implements ApplicationContextAware, Initializing
     private Logger logger = LoggerFactory.getLogger(QuartzJobRegistrar.class);
 
     public final static String BEAN_ID="bean";
+    public static final String JOB_LOCK_SERVICE = "jobLockService";
+
+    private ArrayList<ScheduledQuartzJob> registeredJobs = new ArrayList<ScheduledQuartzJob>();
 
     @Autowired
     protected Scheduler scheduler;
-    private ArrayList<ScheduledQuartzJob> registeredJobs = new ArrayList<ScheduledQuartzJob>();
+
+    @Autowired
+    protected JobLockService jobLockService;
+
+    @Autowired
+    @Qualifier("global-properties")
+    protected Properties globalProperties = new Properties();
 
     private ApplicationContext applicationContext;
 
     @Override
-    public void afterPropertiesSet() throws ParseException, SchedulerException {
+    public void afterPropertiesSet() {
+        this.registerScheduledQuartzJobAnnotatedBeans();
+    }
+
+    public void registerScheduledQuartzJobAnnotatedBeans() {
         Map<String, Object> scheduledBeans = applicationContext.getBeansWithAnnotation(ScheduledQuartzJob.class);
         for (Map.Entry entry : scheduledBeans.entrySet()) {
             Object bean = entry.getValue();
-            Assert.isInstanceOf(Job.class, bean, "annotated Quartz job classes should implement org.quartz.Job");
-
-            ScheduledQuartzJob annotation = bean.getClass().getAnnotation(ScheduledQuartzJob.class);
-
             try {
-                String cron = applicationContext.getBean("global-properties", Properties.class).getProperty(annotation.cronProp(), annotation.cron());
-                CronTrigger trigger = new CronTrigger(annotation.name(), annotation.group(), cron);
-                JobDetail jobDetail = new JobDetail(annotation.name(), annotation.group(), annotation.cluster() ? AbstractScheduledLockedJob.class : GenericQuartzJob.class);
-                JobDataMap map = new JobDataMap();
-                map.put(BEAN_ID, bean);
-                jobDetail.setJobDataMap(map);
-                scheduler.scheduleJob(jobDetail, trigger);
-
-                registeredJobs.add(annotation);
-
-                logger.debug("scheduled job " + annotation.name() + " from group " + annotation.group() + " using cron " + annotation.cron());
+                this.registerJob(bean);
             } catch (Exception e) {
-                logger.error("failed to register job " + annotation.name() + " using cron " + annotation.group(), e);
+                logger.error("Failed to register job: ", e);
             }
         }
     }
 
+    public void registerJob(Object bean) throws ParseException, SchedulerException {
+        Assert.isInstanceOf(Job.class, bean, "annotated Quartz job classes should implement org.quartz.Job");
+
+        ScheduledQuartzJob annotation = bean.getClass().getAnnotation(ScheduledQuartzJob.class);
+
+        String cron = applicationContext.getBean("global-properties", Properties.class).getProperty(annotation.cronProp(), annotation.cron());
+        CronTrigger trigger = new CronTrigger(annotation.name(), annotation.group(), cron);
+        JobDetail jobDetail = new JobDetail(annotation.name(), annotation.group(), annotation.cluster() ? ClusterLockedJob.class : GenericQuartzJob.class);
+
+        JobDataMap map = new JobDataMap();
+        map.put(BEAN_ID, bean);
+        map.put(JOB_LOCK_SERVICE, this.jobLockService);
+
+        jobDetail.setJobDataMap(map);
+        scheduler.scheduleJob(jobDetail, trigger);
+
+        registeredJobs.add(annotation);
+
+        logger.debug("scheduled job " + annotation.name() + " from group " + annotation.group() + " using cron " + annotation.cron());
+    }
+
     @Override
-    public void destroy() throws SchedulerException {
+    public void destroy() {
         for (ScheduledQuartzJob job : registeredJobs) {
             try {
                 scheduler.unscheduleJob(job.name(), job.group());
@@ -76,6 +98,14 @@ public class QuartzJobRegistrar implements ApplicationContextAware, Initializing
 
     public void setApplicationContext(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
+    }
+
+    public void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public void setJobLockService(JobLockService jobLockService) {
+        this.jobLockService = jobLockService;
     }
 
 }

--- a/annotations-runtime/annotations-runtime-52/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrar.java
+++ b/annotations-runtime/annotations-runtime-52/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrar.java
@@ -75,6 +75,7 @@ public class QuartzJobRegistrar implements ApplicationContextAware, Initializing
         JobDataMap map = new JobDataMap();
         map.put(BEAN_ID, bean);
         map.put(JOB_LOCK_SERVICE, this.jobLockService);
+        map.put("name", trigger.getKey().toString());
 
         jobDetail.setJobDataMap(map);
         scheduler.scheduleJob(jobDetail, trigger);

--- a/annotations-runtime/annotations-runtime-60/src/test/java/com/github/dynamicextensionsalfresco/quartz/FakeJobExecutionContext.java
+++ b/annotations-runtime/annotations-runtime-60/src/test/java/com/github/dynamicextensionsalfresco/quartz/FakeJobExecutionContext.java
@@ -1,0 +1,119 @@
+package com.github.dynamicextensionsalfresco.quartz;
+
+import java.util.Date;
+import org.quartz.Calendar;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.Scheduler;
+import org.quartz.Trigger;
+import org.quartz.TriggerKey;
+
+public class FakeJobExecutionContext implements JobExecutionContext {
+
+    private final Scheduler scheduler;
+    private final JobDetail jobDetail;
+    private final Job job;
+
+    public FakeJobExecutionContext(Scheduler scheduler, JobDetail jobDetail, Job job) {
+
+        this.scheduler = scheduler;
+        this.jobDetail = jobDetail;
+        this.job = job;
+    }
+    @Override
+    public Scheduler getScheduler() {
+        return this.scheduler;
+    }
+
+    @Override
+    public Trigger getTrigger() {
+        return null;
+    }
+
+    @Override
+    public Calendar getCalendar() {
+        return null;
+    }
+
+    @Override
+    public boolean isRecovering() {
+        return false;
+    }
+
+    @Override
+    public TriggerKey getRecoveringTriggerKey() throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public int getRefireCount() {
+        return 0;
+    }
+
+    @Override
+    public JobDataMap getMergedJobDataMap() {
+        return null;
+    }
+
+    @Override
+    public JobDetail getJobDetail() {
+        return this.jobDetail;
+    }
+
+    @Override
+    public Job getJobInstance() {
+        return this.job;
+    }
+
+    @Override
+    public Date getFireTime() {
+        return null;
+    }
+
+    @Override
+    public Date getScheduledFireTime() {
+        return null;
+    }
+
+    @Override
+    public Date getPreviousFireTime() {
+        return null;
+    }
+
+    @Override
+    public Date getNextFireTime() {
+        return null;
+    }
+
+    @Override
+    public String getFireInstanceId() {
+        return null;
+    }
+
+    @Override
+    public Object getResult() {
+        return null;
+    }
+
+    @Override
+    public void setResult(Object result) {
+
+    }
+
+    @Override
+    public long getJobRunTime() {
+        return 0;
+    }
+
+    @Override
+    public void put(Object key, Object value) {
+
+    }
+
+    @Override
+    public Object get(Object key) {
+        return null;
+    }
+}

--- a/annotations-runtime/annotations-runtime-60/src/test/java/com/github/dynamicextensionsalfresco/quartz/FakeScheduler.java
+++ b/annotations-runtime/annotations-runtime-60/src/test/java/com/github/dynamicextensionsalfresco/quartz/FakeScheduler.java
@@ -1,0 +1,335 @@
+package com.github.dynamicextensionsalfresco.quartz;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.quartz.Calendar;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobKey;
+import org.quartz.ListenerManager;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerContext;
+import org.quartz.SchedulerException;
+import org.quartz.SchedulerMetaData;
+import org.quartz.Trigger;
+import org.quartz.Trigger.TriggerState;
+import org.quartz.TriggerKey;
+import org.quartz.UnableToInterruptJobException;
+import org.quartz.impl.matchers.GroupMatcher;
+import org.quartz.spi.JobFactory;
+
+public class FakeScheduler implements Scheduler {
+
+    private Map<JobKey, JobDetail> storage = new HashMap<>();
+
+    @Override
+    public Date scheduleJob(JobDetail jobDetail, Trigger trigger) throws SchedulerException {
+        this.storage.put(jobDetail.getKey(), jobDetail);
+        return new Date();
+    }
+
+    @Override
+    public void triggerJob(JobKey jobKey) throws SchedulerException {
+        try {
+            JobDetail detail = storage.get(jobKey);
+            Job job = detail.getJobClass().newInstance();
+            JobExecutionContext context = new FakeJobExecutionContext(this, detail, job);
+
+            job.execute(context);
+        } catch (InstantiationException | IllegalAccessException e) {
+            e.printStackTrace();
+            throw new SchedulerException(e);
+        }
+    }
+
+    /* not implemented methods */
+
+    @Override
+    public String getSchedulerName() throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public String getSchedulerInstanceId() throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public SchedulerContext getContext() throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public void start() throws SchedulerException {
+
+    }
+
+    @Override
+    public void startDelayed(int seconds) throws SchedulerException {
+
+    }
+
+    @Override
+    public boolean isStarted() throws SchedulerException {
+        return false;
+    }
+
+    @Override
+    public void standby() throws SchedulerException {
+
+    }
+
+    @Override
+    public boolean isInStandbyMode() throws SchedulerException {
+        return false;
+    }
+
+    @Override
+    public void shutdown() throws SchedulerException {
+
+    }
+
+    @Override
+    public void shutdown(boolean waitForJobsToComplete) throws SchedulerException {
+
+    }
+
+    @Override
+    public boolean isShutdown() throws SchedulerException {
+        return false;
+    }
+
+    @Override
+    public SchedulerMetaData getMetaData() throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public List<JobExecutionContext> getCurrentlyExecutingJobs() throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public void setJobFactory(JobFactory factory) throws SchedulerException {
+
+    }
+
+    @Override
+    public ListenerManager getListenerManager() throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public Date scheduleJob(Trigger trigger) throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public void scheduleJobs(Map<JobDetail, Set<? extends Trigger>> triggersAndJobs, boolean replace)
+            throws SchedulerException {
+
+    }
+
+    @Override
+    public void scheduleJob(JobDetail jobDetail, Set<? extends Trigger> triggersForJob, boolean replace)
+            throws SchedulerException {
+
+    }
+
+    @Override
+    public boolean unscheduleJob(TriggerKey triggerKey) throws SchedulerException {
+        return false;
+    }
+
+    @Override
+    public boolean unscheduleJobs(List<TriggerKey> triggerKeys) throws SchedulerException {
+        return false;
+    }
+
+    @Override
+    public Date rescheduleJob(TriggerKey triggerKey, Trigger newTrigger) throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public void addJob(JobDetail jobDetail, boolean replace) throws SchedulerException {
+
+    }
+
+    @Override
+    public void addJob(JobDetail jobDetail, boolean replace, boolean storeNonDurableWhileAwaitingScheduling)
+            throws SchedulerException {
+
+    }
+
+    @Override
+    public boolean deleteJob(JobKey jobKey) throws SchedulerException {
+        return false;
+    }
+
+    @Override
+    public boolean deleteJobs(List<JobKey> jobKeys) throws SchedulerException {
+        return false;
+    }
+
+
+
+    @Override
+    public void triggerJob(JobKey jobKey, JobDataMap data) throws SchedulerException {
+
+    }
+
+    @Override
+    public void pauseJob(JobKey jobKey) throws SchedulerException {
+
+    }
+
+    @Override
+    public void pauseJobs(GroupMatcher<JobKey> matcher) throws SchedulerException {
+
+    }
+
+    @Override
+    public void pauseTrigger(TriggerKey triggerKey) throws SchedulerException {
+
+    }
+
+    @Override
+    public void pauseTriggers(GroupMatcher<TriggerKey> matcher) throws SchedulerException {
+
+    }
+
+    @Override
+    public void resumeJob(JobKey jobKey) throws SchedulerException {
+
+    }
+
+    @Override
+    public void resumeJobs(GroupMatcher<JobKey> matcher) throws SchedulerException {
+
+    }
+
+    @Override
+    public void resumeTrigger(TriggerKey triggerKey) throws SchedulerException {
+
+    }
+
+    @Override
+    public void resumeTriggers(GroupMatcher<TriggerKey> matcher) throws SchedulerException {
+
+    }
+
+    @Override
+    public void pauseAll() throws SchedulerException {
+
+    }
+
+    @Override
+    public void resumeAll() throws SchedulerException {
+
+    }
+
+    @Override
+    public List<String> getJobGroupNames() throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public Set<JobKey> getJobKeys(GroupMatcher<JobKey> matcher) throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public List<? extends Trigger> getTriggersOfJob(JobKey jobKey) throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public List<String> getTriggerGroupNames() throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public Set<TriggerKey> getTriggerKeys(GroupMatcher<TriggerKey> matcher) throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public Set<String> getPausedTriggerGroups() throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public JobDetail getJobDetail(JobKey jobKey) throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public Trigger getTrigger(TriggerKey triggerKey) throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public TriggerState getTriggerState(TriggerKey triggerKey) throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public void resetTriggerFromErrorState(TriggerKey triggerKey) throws SchedulerException {
+
+    }
+
+    @Override
+    public void addCalendar(String calName, Calendar calendar, boolean replace, boolean updateTriggers)
+            throws SchedulerException {
+
+    }
+
+    @Override
+    public boolean deleteCalendar(String calName) throws SchedulerException {
+        return false;
+    }
+
+    @Override
+    public Calendar getCalendar(String calName) throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public List<String> getCalendarNames() throws SchedulerException {
+        return null;
+    }
+
+    @Override
+    public boolean interrupt(JobKey jobKey) throws UnableToInterruptJobException {
+        return false;
+    }
+
+    @Override
+    public boolean interrupt(String fireInstanceId) throws UnableToInterruptJobException {
+        return false;
+    }
+
+    @Override
+    public boolean checkExists(JobKey jobKey) throws SchedulerException {
+        return false;
+    }
+
+    @Override
+    public boolean checkExists(TriggerKey triggerKey) throws SchedulerException {
+        return false;
+    }
+
+    @Override
+    public void clear() throws SchedulerException {
+
+    }
+}

--- a/annotations-runtime/annotations-runtime-60/src/test/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrarTest.java
+++ b/annotations-runtime/annotations-runtime-60/src/test/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrarTest.java
@@ -1,0 +1,74 @@
+package com.github.dynamicextensionsalfresco.quartz;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.github.dynamicextensionsalfresco.jobs.ScheduledQuartzJob;
+import org.alfresco.repo.lock.JobLockService;
+import org.junit.Test;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+
+public class QuartzJobRegistrarTest {
+
+    @Test
+    public void testScheduledJob() throws SchedulerException {
+        TestJob job = new TestJob();
+
+        ScheduledQuartzJob annotation = job.getClass().getAnnotation(ScheduledQuartzJob.class);
+        assertNotNull("Job not annotated with @ScheduledQuartzJob", annotation);
+        Scheduler scheduler = new FakeScheduler();
+
+        QuartzJobRegistrar registrar = new QuartzJobRegistrar();
+        registrar.setScheduler(scheduler);
+        registrar.registerJob(job);
+
+        scheduler.triggerJob(new JobKey(annotation.name(), annotation.group()));
+
+        assertTrue("scheduled job was not executed", job.isExecuted());
+    }
+
+    @Test
+    public void testClusteredJob() throws SchedulerException {
+        TestJob job = new TestClusteredJob();
+
+        ScheduledQuartzJob annotation = job.getClass().getAnnotation(ScheduledQuartzJob.class);
+        assertNotNull("Job not annotated with @ScheduledQuartzJob", annotation);
+        Scheduler scheduler = new FakeScheduler();
+
+        QuartzJobRegistrar registrar = new QuartzJobRegistrar();
+        registrar.setScheduler(scheduler);
+        registrar.setJobLockService(mock(JobLockService.class));
+
+        registrar.registerJob(job);
+
+        scheduler.triggerJob(new JobKey(annotation.name(), annotation.group()));
+
+        assertTrue("scheduled job was not executed", job.isExecuted());
+    }
+
+
+    @ScheduledQuartzJob(cron = "*/15 * * ? * *", name = "test")
+    public class TestJob implements Job {
+
+        private boolean executed = false;
+
+        @Override
+        public void execute(JobExecutionContext jobExecutionContext) {
+            this.executed = true;
+        }
+
+        boolean isExecuted() {
+            return executed;
+        }
+    }
+
+    @ScheduledQuartzJob(cron = "*/15 * * ? * *", name = "cluster", cluster = true)
+    public class TestClusteredJob extends TestJob {
+
+    }
+}

--- a/annotations-runtime/build.gradle
+++ b/annotations-runtime/build.gradle
@@ -57,6 +57,7 @@ subprojects {
         testRuntime("org.hibernate:hibernate:${project.ext.hibernateVersion}") {
             exclude group: "javax.transaction"
         }
+        testRuntime "org.slf4j:slf4j-log4j12"
         testRuntime 'cglib:cglib-nodep:2.2'
         testRuntime 'xerces:xercesImpl:2.8.0'
 

--- a/annotations-runtime/shared/src/main/java/com/github/dynamicextensionsalfresco/quartz/ClusterLockedJob.java
+++ b/annotations-runtime/shared/src/main/java/com/github/dynamicextensionsalfresco/quartz/ClusterLockedJob.java
@@ -1,0 +1,13 @@
+package com.github.dynamicextensionsalfresco.quartz;
+
+import org.alfresco.schedule.AbstractScheduledLockedJob;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+public class ClusterLockedJob extends AbstractScheduledLockedJob {
+
+    @Override
+    public void executeJob(JobExecutionContext jobContext) throws JobExecutionException {
+        QuartzJobAdaptor.execute(jobContext);
+    }
+}

--- a/annotations-runtime/shared/src/main/java/com/github/dynamicextensionsalfresco/quartz/GenericQuartzJob.java
+++ b/annotations-runtime/shared/src/main/java/com/github/dynamicextensionsalfresco/quartz/GenericQuartzJob.java
@@ -1,19 +1,13 @@
 package com.github.dynamicextensionsalfresco.quartz;
 
-import java.util.Map;
 import org.quartz.Job;
-import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
 public final class GenericQuartzJob implements Job {
 
     public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
-        JobDetail jobDetail = jobExecutionContext.getJobDetail();
-        Map jobDataMap = jobDetail.getJobDataMap();
-        Object obj = jobDataMap.get(QuartzJobRegistrar.BEAN_ID);
-        Job lockedJob = (Job)obj;
-        lockedJob.execute(jobExecutionContext);
+       QuartzJobAdaptor.execute(jobExecutionContext);
     }
 
 }

--- a/annotations-runtime/shared/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobAdaptor.java
+++ b/annotations-runtime/shared/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobAdaptor.java
@@ -1,0 +1,18 @@
+package com.github.dynamicextensionsalfresco.quartz;
+
+import java.util.Map;
+import org.quartz.Job;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+public class QuartzJobAdaptor {
+
+    public static void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+        JobDetail jobDetail = jobExecutionContext.getJobDetail();
+        Map jobDataMap = jobDetail.getJobDataMap();
+        Object obj = jobDataMap.get(QuartzJobRegistrar.BEAN_ID);
+        Job lockedJob = (Job)obj;
+        lockedJob.execute(jobExecutionContext);
+    }
+}

--- a/annotations-runtime/shared/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrar.java
+++ b/annotations-runtime/shared/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrar.java
@@ -82,6 +82,7 @@ public class QuartzJobRegistrar implements ApplicationContextAware, Initializing
         JobDataMap map = new JobDataMap();
         map.put(BEAN_ID, bean);
         map.put(JOB_LOCK_SERVICE, this.jobLockService);
+        map.put("name", trigger.getKey().toString());
 
         JobDetail jobDetail = JobBuilder
                 .newJob(annotation.cluster() ? ClusterLockedJob.class : GenericQuartzJob.class)

--- a/annotations-runtime/shared/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrar.java
+++ b/annotations-runtime/shared/src/main/java/com/github/dynamicextensionsalfresco/quartz/QuartzJobRegistrar.java
@@ -1,10 +1,10 @@
 package com.github.dynamicextensionsalfresco.quartz;
 
 import com.github.dynamicextensionsalfresco.jobs.ScheduledQuartzJob;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Properties;
+import org.alfresco.repo.lock.JobLockService;
 import org.alfresco.schedule.AbstractScheduledLockedJob;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.CronTrigger;
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.util.Assert;
@@ -30,46 +31,70 @@ import org.springframework.util.Assert;
  * the implementation for older Alfresco versions.
  */
 public class QuartzJobRegistrar implements ApplicationContextAware, InitializingBean, DisposableBean {
+
+
     private Logger logger = LoggerFactory.getLogger(QuartzJobRegistrar.class);
 
-    public final static String BEAN_ID="bean";
+    public final static String BEAN_ID = "bean";
+    public static final String JOB_LOCK_SERVICE = "jobLockService";
+
+    private ArrayList<ScheduledQuartzJob> registeredJobs = new ArrayList<ScheduledQuartzJob>();
 
     @Autowired
     protected Scheduler scheduler;
-    private ArrayList<ScheduledQuartzJob> registeredJobs = new ArrayList<ScheduledQuartzJob>();
+
+    @Autowired
+    protected JobLockService jobLockService;
+
+    @Autowired
+    @Qualifier("global-properties")
+    protected Properties globalProperties = new Properties();
 
     private ApplicationContext applicationContext;
 
     @Override
-    public void afterPropertiesSet() throws ParseException, SchedulerException {
+    public void afterPropertiesSet() {
+        this.registerScheduledQuartzJobAnnotatedBeans();
+    }
+
+    public void registerScheduledQuartzJobAnnotatedBeans() {
         Map<String, Object> scheduledBeans = applicationContext.getBeansWithAnnotation(ScheduledQuartzJob.class);
         for (Map.Entry entry : scheduledBeans.entrySet()) {
             Object bean = entry.getValue();
-            Assert.isInstanceOf(Job.class, bean, "annotated Quartz job classes should implement org.quartz.Job");
-
-            ScheduledQuartzJob annotation = bean.getClass().getAnnotation(ScheduledQuartzJob.class);
-
             try {
-                String cron = applicationContext.getBean("global-properties", Properties.class).getProperty(annotation.cronProp(), annotation.cron());
-                CronTrigger trigger =TriggerBuilder.newTrigger()
-                        .withIdentity(annotation.name(), annotation.group())
-                        .withSchedule(CronScheduleBuilder.cronSchedule(cron))
-                        .build();
-                JobDataMap map = new JobDataMap();
-                map.put(BEAN_ID, bean);
-                JobDetail jobDetail = JobBuilder.newJob(annotation.cluster() ? AbstractScheduledLockedJob.class : GenericQuartzJob.class)
-                        .withIdentity(annotation.name(), annotation.group())
-                        .usingJobData(map)
-                        .build();
-                scheduler.scheduleJob(jobDetail, trigger);
-
-                registeredJobs.add(annotation);
-
-                logger.debug("scheduled job " + annotation.name() + " from group " + annotation.group() + " using cron " + annotation.cron());
+                this.registerJob(bean);
             } catch (Exception e) {
-                logger.error("failed to register job " + annotation.name() + " using cron " + annotation.group(), e);
+                logger.error("Failed to register job: ", e);
             }
         }
+    }
+
+    public void registerJob(Object bean) throws SchedulerException {
+        Assert.isInstanceOf(Job.class, bean, "annotated Quartz job classes should implement org.quartz.Job");
+
+        ScheduledQuartzJob annotation = bean.getClass().getAnnotation(ScheduledQuartzJob.class);
+
+        String cron = this.globalProperties.getProperty(annotation.cronProp(), annotation.cron());
+        CronTrigger trigger = TriggerBuilder.newTrigger()
+                .withIdentity(annotation.name(), annotation.group())
+                .withSchedule(CronScheduleBuilder.cronSchedule(cron))
+                .build();
+        JobDataMap map = new JobDataMap();
+        map.put(BEAN_ID, bean);
+        map.put(JOB_LOCK_SERVICE, this.jobLockService);
+
+        JobDetail jobDetail = JobBuilder
+                .newJob(annotation.cluster() ? ClusterLockedJob.class : GenericQuartzJob.class)
+                .withIdentity(annotation.name(), annotation.group())
+                .usingJobData(map)
+                .build();
+        scheduler.scheduleJob(jobDetail, trigger);
+
+        registeredJobs.add(annotation);
+
+        logger.debug("scheduled job " + annotation.name() + " from group " + annotation.group() + " using cron "
+                + annotation.cron());
+
     }
 
     @Override
@@ -86,6 +111,14 @@ public class QuartzJobRegistrar implements ApplicationContextAware, Initializing
 
     public void setApplicationContext(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
+    }
+
+    public void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public void setJobLockService(JobLockService jobLockService) {
+        this.jobLockService = jobLockService;
     }
 
 }


### PR DESCRIPTION
This PR fixes issue #226

`@ScheduledQuartzJob` got a parameter `cluster=true` but this never actually worked.

The mean idea is to use the Alfresco-provided `AbstractScheduledLockedJob`, that facilitates running scheduled jobs in an Alfresco cluster, but avoids running the same job on multiple nodes in the cluster at the same time by making use of Alfresco's central locking support.

There are a couple problems:

1. `AbstractScheduledLockedJob` is an abstract class and Quartz failed to create an instance when triggering a job - you need to subclass this
2. The `AbstractScheduledLockedJob` has a dependency on `JobLockService`, which is not using Spring DI, but is loaded form the `JobDataMap`
3. The locking key is a string identifier, which defaults to the class-name of the Quartz-job. Because DE is using an adapter, the locking key is the adapter-classname. Which results in that two different DE-clustered-jobs can't run at the same time and they get skipped!

How this PR addresses these issues:
1. New class `ClusterLockedJob` subclasses `AbstractScheduledLockedJob`. When `cluster=true`, `ClusterLockedJob.class` is passed to Quartz. Code duplication between the existing `GenericQuartzJob` and the new `ClusterLockedJob` is avoided by delegating to a new class `QuartzJobAdaptor` 
2. `QuartzJobRegistrar` now puts `JobLockService` in the `JobDataMap`, so `AbstractScheduledLockedJob` can extract that when a job is  executed
3. `QuartzJobRegistrar` now puts a name property in the `JobDataMap` which equals the quartz job-name (`= annotation.group() + "." + annotation.name()`)