### PR TITLE
Use alfresco-hotfix-MNT-20557 as workaround for MNT-20557

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,11 @@ of the `Resource` class embedded in the distribution, and the
 [`bootstrap` classloader has the highest priority](https://tomcat.apache.org/tomcat-9.0-doc/class-loader-howto.html).
 
 This issue has been reported to Alfresco: [MNT-20557](https://issues.alfresco.com/jira/browse/MNT-20557). 
-As a workaround DE can work on Alfresco 6.1 if the `jsr250-api` and `geronimo-annotation_1.0_spec` jars are 
-removed from the `WEB-INF/lib` folder.
+Waiting for Alfresco to fix the issue, following workarounds can be used to make DE work on Alfresco 6.1:
+
+* Remove the `jsr250-api` and `geronimo-annotation_1.0_spec` jars from the `WEB-INF/lib` folder of the Alfresco webapp.
+* Install [this hotfix AMP](https://github.com/xenit-eu/alfresco-hotfix-MNT-20557) in your Alfresco distribution, 
+which will overwrite the `jsr250-api` and `geronimo-annotation_1.0_spec` jars with empty jars.
 
 Example extension code
 ----------------------

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -51,6 +51,11 @@ configure(subprojects.findAll { it.name.startsWith("alfresco-") }) {
     dependencies {
         baseAlfrescoWar "${alfrescoBaseWar}"
         alfrescoAmp project(path: ":alfresco-dynamic-extensions-repo:alfresco-dynamic-extensions-repo-${alfrescoVersion}", configuration: 'ampArtifact')
+
+        if ("61" == "${alfrescoVersion}") {
+            // Workaround for https://issues.alfresco.com/jira/browse/MNT-20557
+            alfrescoAmp "eu.xenit.alfresco:alfresco-hotfix-MNT-20557:1.0.1@amp"
+        }
         
         baseShareWar "${shareBaseWar}"
     }
@@ -68,10 +73,6 @@ configure(subprojects.findAll { it.name.startsWith("alfresco-") }) {
     createDockerFile {
         // Workaround for https://issues.alfresco.com/jira/browse/MNT-20007
         runCommand("sed -i 's|<secure>true</secure>|<secure>false</secure>|g' /usr/local/tomcat/conf/web.xml")
-
-        // Workaround for https://issues.alfresco.com/jira/browse/MNT-20557
-        runCommand("rm -f /usr/local/tomcat/webapps/alfresco/WEB-INF/lib/jsr250-api-1.0.jar")
-        runCommand("rm -f /usr/local/tomcat/webapps/alfresco/WEB-INF/lib/geronimo-annotation_1.0_spec-1.1.1.jar")
     }
 
     dockerCompose {


### PR DESCRIPTION
Issue: DE doesn't work on Alfresco 6.1 because there are implementations of the JSR 250 specification in the distribution and an old implementation is used.
https://github.com/xenit-eu/alfresco-hotfix-MNT-20557 builds and amp which can be installed as a workaround for this issue. 

This PR adds this workaround to the documentation and actually uses this workaround for the integration tests.