### PR TITLE
Fix @ScheduledTask, fix DEApplicationContext javadoc

### DIFF
--- a/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/schedule/ScheduledTaskRegistrar.java
+++ b/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/schedule/ScheduledTaskRegistrar.java
@@ -42,7 +42,9 @@ public class ScheduledTaskRegistrar implements ApplicationContextAware, Initiali
     }
 
     public void registerScheduledTaskAnnotatedBeans() {
-        Map<String, Object> scheduledBeans = applicationContext.getBeansWithAnnotation(ScheduledQuartzJob.class);
+        Map<String, Object> scheduledBeans = applicationContext.getBeansWithAnnotation(ScheduledTask.class);
+        scheduledBeans.putAll(applicationContext.getBeansWithAnnotation(ScheduledQuartzJob.class));
+
         for (Map.Entry entry : scheduledBeans.entrySet()) {
             Object bean = entry.getValue();
             try {

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/schedule/ScheduledTaskRegistrarTest.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/schedule/ScheduledTaskRegistrarTest.java
@@ -2,31 +2,47 @@ package com.github.dynamicextensionsalfresco.schedule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.github.dynamicextensionsalfresco.jobs.ScheduledQuartzJob;
+import java.util.Collections;
+import org.junit.Before;
 import org.junit.Test;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
+import org.springframework.context.ApplicationContext;
 
 public class ScheduledTaskRegistrarTest {
+
+    private ScheduledTaskRegistrar registrar;
+    private ApplicationContext applicationContext;
+
+    @Before
+    public void setup() {
+        applicationContext = mock(ApplicationContext.class);
+
+        registrar = new ScheduledTaskRegistrar();
+        registrar.setApplicationContext(applicationContext);
+
+    }
 
     @Test
     public void taskGetsScheduled() throws TaskSchedulerException {
         TestTask task = new TestTask();
+        when(applicationContext.getBeansWithAnnotation(ScheduledTask.class))
+                .thenReturn(Collections.singletonMap("scheduled-task", task));
 
         ScheduledTask annotation = task.getClass().getAnnotation(ScheduledTask.class);
         assertNotNull("Job not annotated with @ScheduledTask", annotation);
         TaskScheduler scheduler = mock(TaskScheduler.class);
 
-        ScheduledTaskRegistrar registrar = new ScheduledTaskRegistrar();
         registrar.setScheduler(scheduler);
 
-        registrar.registerTask(task);
+        registrar.afterPropertiesSet();
 
         verify(scheduler, times(1))
                 .scheduleTask(any(TaskConfiguration.class), any(Task.class));
@@ -35,12 +51,13 @@ public class ScheduledTaskRegistrarTest {
     @Test
     public void deprecatedQuartzJobGetsScheduled() throws TaskSchedulerException {
         TestQuartzJob job = new TestQuartzJob();
+        when(applicationContext.getBeansWithAnnotation(ScheduledQuartzJob.class))
+                .thenReturn(Collections.singletonMap("scheduled-job", job));
 
         ScheduledQuartzJob annotation = job.getClass().getAnnotation(ScheduledQuartzJob.class);
         assertNotNull("Job not annotated with @ScheduledQuartzJob", annotation);
         TaskScheduler scheduler = mock(TaskScheduler.class);
 
-        ScheduledTaskRegistrar registrar = new ScheduledTaskRegistrar();
         registrar.setScheduler(scheduler);
 
         registrar.registerTask(job);

--- a/blueprint-integration/src/main/java/com/github/dynamicextensionsalfresco/blueprint/DynamicExtensionsApplicationContext.java
+++ b/blueprint-integration/src/main/java/com/github/dynamicextensionsalfresco/blueprint/DynamicExtensionsApplicationContext.java
@@ -44,6 +44,8 @@ import org.osgi.service.packageadmin.PackageAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -51,6 +53,7 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.xml.DefaultNamespaceHandlerResolver;
 import org.springframework.beans.factory.xml.DelegatingEntityResolver;
+import org.springframework.beans.factory.xml.NamespaceHandler;
 import org.springframework.beans.factory.xml.NamespaceHandlerResolver;
 import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
 import org.springframework.context.ApplicationContext;
@@ -60,10 +63,10 @@ import org.springframework.util.StringUtils;
 import org.xml.sax.EntityResolver;
 
 /**
- * [ApplicationContext] for Dynamic Extensions.
+ * {@link ApplicationContext} for Dynamic Extensions.
  *
  *
- * This implementation populates the [BeanFactory] with [BeanDefinition]s by scanning for classes in packages listed in
+ * This implementation populates the {@link BeanFactory} with {@link BeanDefinition}s by scanning for classes in packages listed in
  * the bundle's {@value #SPRING_CONFIGURATION_HEADER} header. This enables XML-free configuration.
  *
  *
@@ -78,7 +81,7 @@ import org.xml.sax.EntityResolver;
  *
  *
  * If Spring XML configuration is present in the classpath folder `/META-INF/spring` this implementation falls back on
- * creating an [ApplicationContext] by combining configuration from all XML files in this folder.
+ * creating an {@link ApplicationContext} by combining configuration from all XML files in this folder.
  *
  *
  * This implementation works around classloading issues for Spring XML [NamespaceHandler]s when *embedding* the
@@ -87,9 +90,9 @@ import org.xml.sax.EntityResolver;
  * framework, but through the embedding application's classloader.
  *
  *
- * Specifically, this class loads bean definitions by creating an [XmlBeanDefinitionReader] configured with a
- * [NamespaceHandlerResolver] and an [EntityResolver] obtained from the embedding application. This, in turn, causes the
- * Spring XML configuration to be handled by [NamespaceHandler]s from the Spring libraries bundled with Alfresco. These
+ * Specifically, this class loads bean definitions by creating an {@link XmlBeanDefinitionReader} configured with a
+ * {@link NamespaceHandlerResolver} and an {@link EntityResolver} obtained from the embedding application. This, in turn, causes the
+ * Spring XML configuration to be handled by {@link NamespaceHandler}s from the Spring libraries bundled with Alfresco. These
  * services must have a `hostApplication` property that is set to the value "alfresco" for this to work.
  *
  *

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "eu.xenit.docker-alfresco" version "4.0.2" apply false
+    id "eu.xenit.docker-alfresco" version "4.0.3" apply false
 }
 
 apply plugin: 'java'


### PR DESCRIPTION
Fixes

- `@ScheduledTask` tasks not registered
- Upgrades the `eu.xenit.docker-alfresco` Gradle plugin
- Fixed the `DynamicExtensionsApplicationContext` Javadoc, which was still in the Kotlin format