### PR TITLE
Revert #246 loadBeanDefinitions only from 'Export-Packages'

### DIFF
--- a/annotations-runtime/scheduler-quartz-1/src/main/java/com/github/dynamicextensionsalfresco/schedule/quartz/QuartzTaskScheduler.java
+++ b/annotations-runtime/scheduler-quartz-1/src/main/java/com/github/dynamicextensionsalfresco/schedule/quartz/QuartzTaskScheduler.java
@@ -51,8 +51,8 @@ public class QuartzTaskScheduler implements TaskScheduler {
             if (Task.class.isAssignableFrom(bean.getClass())) {
                 // this is the expected type, carry on
             } else if (Job.class.isAssignableFrom(bean.getClass())) {
-                log.warn("[DEPRECATION] Implementing {} directly is deprecated, please implement {}",
-                        Job.class.getName(), Task.class.getName());
+                log.warn("[DEPRECATION] '{}' Implementing {} directly is deprecated, please implement {}",
+                        bean.getClass().getCanonicalName(), Job.class.getName(), Task.class.getName());
             } else {
                 throw new IllegalArgumentException(String.format("argument 'bean' does not implement interface " +
                         Task.class.getName()));

--- a/annotations-runtime/scheduler-quartz-2/src/main/java/com/github/dynamicextensionsalfresco/schedule/quartz2/Quartz2TaskScheduler.java
+++ b/annotations-runtime/scheduler-quartz-2/src/main/java/com/github/dynamicextensionsalfresco/schedule/quartz2/Quartz2TaskScheduler.java
@@ -54,8 +54,8 @@ public class Quartz2TaskScheduler implements TaskScheduler {
             if (Task.class.isAssignableFrom(bean.getClass())) {
                 // this is the expected type, carry on
             } else if (Job.class.isAssignableFrom(bean.getClass())) {
-                log.warn("[DEPRECATION] Implementing {} directly is deprecated, please implement {}",
-                        Job.class.getName(), Task.class.getName());
+                log.warn("[DEPRECATION] '{}' Implementing {} directly is deprecated, please implement {}",
+                        bean.getClass().getCanonicalName(), Job.class.getName(), Task.class.getName());
             } else {
                 throw new IllegalArgumentException(String.format("argument 'bean' does not implement interface " +
                         Task.class.getName()));

--- a/blueprint-integration/build.gradle
+++ b/blueprint-integration/build.gradle
@@ -68,6 +68,7 @@ dependencies {
 
     testCompile platform("${project.ext.alfrescoBom}")
 
+    testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile "org.mockito:mockito-core:${project.ext.mockitoVersion}"
     testCompile "junit:junit:${project.ext.junitVersion}"
     testCompile('org.springframework:spring-beans') { transitive = false }

--- a/blueprint-integration/src/main/java/com/github/dynamicextensionsalfresco/blueprint/DynamicExtensionsApplicationContext.java
+++ b/blueprint-integration/src/main/java/com/github/dynamicextensionsalfresco/blueprint/DynamicExtensionsApplicationContext.java
@@ -33,9 +33,6 @@ import com.github.dynamicextensionsalfresco.workflow.activiti.DefaultWorkflowTas
 import com.github.dynamicextensionsalfresco.workflow.activiti.WorkflowTaskRegistrar;
 import com.github.dynamicextensionsalfresco.workflow.activiti.WorkflowTaskRegistry;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 import org.alfresco.service.descriptor.Descriptor;
 import org.alfresco.service.descriptor.DescriptorService;
 import org.alfresco.service.namespace.NamespacePrefixResolver;
@@ -43,7 +40,9 @@ import org.alfresco.util.VersionNumber;
 import org.eclipse.gemini.blueprint.context.support.OsgiBundleXmlApplicationContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.osgi.framework.wiring.BundleWiring;
+import org.osgi.framework.Constants;
+import org.osgi.service.packageadmin.ExportedPackage;
+import org.osgi.service.packageadmin.PackageAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -156,7 +155,7 @@ public class DynamicExtensionsApplicationContext extends OsgiBundleXmlApplicatio
                 log.warn("Error parsing bean definitions.", ex);
             }
         } else if (isAlfrescoDynamicExtension) {
-            this.scanPackages(beanFactory, this.getAllPackagesInBundle());
+            this.scanPackages(beanFactory, this.getBundleExportPackages());
         }
 
         if (isAlfrescoDynamicExtension) {
@@ -242,27 +241,23 @@ public class DynamicExtensionsApplicationContext extends OsgiBundleXmlApplicatio
         return getService(EntityResolver.class, HOST_APPLICATION_ALFRESCO_FILTER);
     }
 
-    private String[] getAllPackagesInBundle() {
-        final Set<String> packagesInBundle = new HashSet<>();
+    /**
+     * Use the deprecated PackageAdmin to get the list of exported packages.
+     */
+    protected String[] getBundleExportPackages() {
+        String exportPackageHeader = this.getBundle().getHeaders().get(Constants.EXPORT_PACKAGE);
+        if (StringUtils.hasText(exportPackageHeader)) {
+            PackageAdmin packageAdmin = getService(PackageAdmin.class);
+            ExportedPackage[] packages = packageAdmin.getExportedPackages(this.getBundle());
 
-        BundleWiring bundleWiring = this.getBundle().adapt(BundleWiring.class);
-        if (bundleWiring != null) {
-            Collection<String> classes = bundleWiring.listResources("/", "*.class",
-                    BundleWiring.LISTRESOURCES_LOCAL | BundleWiring.LISTRESOURCES_RECURSE);
-            for (String path : classes) {
-                int beginIndex = 0;
-                if (path.startsWith("/")) {
-                    beginIndex = 1;
-                }
-                int endIndex = path.lastIndexOf('/');
-                if (endIndex >= 0) {
-                    path = path.substring(beginIndex, endIndex);
-                    packagesInBundle.add(path.replace('/', '.'));
-                }
+            String[] pkgNames = new String[packages.length];
+            for (int index = 0; index != packages.length; index++) {
+                pkgNames[index] = packages[index].getName();
             }
-        }
 
-        return packagesInBundle.toArray(new String[0]);
+            return pkgNames;
+        }
+        return new String[0];
     }
 
     protected boolean hasXmlConfiguration() {

--- a/blueprint-integration/src/test/java/com/github/dynamicextensionsalfresco/blueprint/DynamicExtensionsApplicationContextTest.java
+++ b/blueprint-integration/src/test/java/com/github/dynamicextensionsalfresco/blueprint/DynamicExtensionsApplicationContextTest.java
@@ -1,9 +1,9 @@
 package com.github.dynamicextensionsalfresco.blueprint;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -13,13 +13,12 @@ import static org.mockito.Mockito.when;
 import com.github.dynamicextensionsalfresco.BeanNames;
 import com.github.dynamicextensionsalfresco.schedule.quartz.QuartzTaskScheduler;
 import com.github.dynamicextensionsalfresco.schedule.quartz2.Quartz2TaskScheduler;
+import java.util.List;
 import org.alfresco.service.descriptor.Descriptor;
 import org.alfresco.util.VersionNumber;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 
 public class DynamicExtensionsApplicationContextTest {
@@ -63,5 +62,16 @@ public class DynamicExtensionsApplicationContextTest {
             // Expecting class Quartz2TaskScheduler on Alfresco 6.x
             assertThat(beanDefCaptor.getValue().getBeanClassName(), is(Quartz2TaskScheduler.class.getName()));
         }
+    }
+
+    public static class UtilityOperationsTest {
+
+        @Test
+        public void recursifyPackage() {
+            List<String> packagesRecursive = DynamicExtensionsApplicationContext.recursifyPackage("eu.xenit.test");
+            assertThat(packagesRecursive, containsInAnyOrder("eu", "eu.xenit", "eu.xenit.test"));
+            assertThat(packagesRecursive, hasSize(3));
+        }
+
     }
 }

--- a/documentation/Building_Bundles.md
+++ b/documentation/Building_Bundles.md
@@ -37,11 +37,16 @@ to the standard OSGi Bundle headers.
     Alfresco integration.
     
 * `Alfresco-Spring-Configuration: eu.xenit.de.example`  
-    This optional header can be used to indicate which packages of your Bundle need to be scanned for Spring beans.  
+    This optional header can be used to indicate which packages of your Bundle need to be scanned for Spring beans. 
+    Package scanning works recursively and you **SHOULD NOT** add any parent package of a package 
+    listed in the `Import-Package` MANIFEST header. This could cause issue like the unintended, duplicate 
+    registration of Spring beans.
+    
     If this header is not present, Dynamic Extensions will scan for Spring XML configuration files in the 
-    `/META-INF/spring` directory of the Bundle.  
-    If there also is no Spring XML configuration present in the bundle, all the packages
-    inside the Bundle will be scanned for Spring beans.
+    `/META-INF/spring` directory of the Bundle.
+    
+    If there also is no Spring XML configuration present in the bundle, all the packages of the 'Export-Package'
+    MANIFEST header will be recursively scanned for Spring beans.
     
 
 ### Building DE OSGi Bundles using Gradle


### PR DESCRIPTION
In PR #248, we introduced a change in classpath scanning behavior: instead of only scanning the 'Export-Packages' packages, all packages of the bundles are now scanned for beans. 

We revert this change because this can cause unintended scanning of some packages.

Small recap of how the classpath scanning actually works in DE:
1. DE checks for the 'Alfresco-Spring-Configuration' MANIFEST header, if this header contains packages these packages will be scanned.
2. DE checks for Spring XML config files in /META-INF/spring/ folder. If there are any Spring configuration files, these are used.
3. If not 1. or 2. DE will fallback on scanning the 'Export-Package' packages. 

This PR has only impact on 3. 

