### PR TITLE
Fix publishing of the Gradle plugin to Maven Central

### DIFF
--- a/alfresco-dynamic-extensions-repo/build.gradle
+++ b/alfresco-dynamic-extensions-repo/build.gradle
@@ -93,7 +93,7 @@ subprojects {
 
     publishing {
         publications {
-            mavenJava(MavenPublication) {
+            mavenAmp(MavenPublication) {
                 artifact amp
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,16 @@ subprojects {
         bndVersion = '2.4.1'
     }
 
-    if (project.name == 'alfresco-dynamic-extensions-repo' || project.parent.name == 'alfresco-dynamic-extensions-repo') {
+    tasks.withType(JavaCompile) {
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
+
+        options.encoding = "UTF-8"
+        options.compilerArgs << '-Xlint:unchecked'
+    }
+
+    if (project.name == 'alfresco-dynamic-extensions-repo' || project.parent.name == 'alfresco-dynamic-extensions-repo'
+            || project.name == 'gradle-plugin') {
         return
     }
 
@@ -102,14 +111,6 @@ subprojects {
     task javadocJar(type: Jar, dependsOn: javadoc) {
         classifier = 'javadoc'
         from javadoc.destinationDir
-    }
-
-    tasks.withType(JavaCompile) {
-        sourceCompatibility = 1.8
-        targetCompatibility = 1.8
-
-        options.encoding = "UTF-8"
-        options.compilerArgs << '-Xlint:unchecked'
     }
 
     apply from: "${rootProject.projectDir}/publish.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -95,8 +95,7 @@ subprojects {
         options.compilerArgs << '-Xlint:unchecked'
     }
 
-    if (project.name == 'alfresco-dynamic-extensions-repo' || project.parent.name == 'alfresco-dynamic-extensions-repo'
-            || project.name == 'gradle-plugin') {
+    if (project.name == 'alfresco-dynamic-extensions-repo' || project.parent.name == 'alfresco-dynamic-extensions-repo') {
         return
     }
 
@@ -124,7 +123,6 @@ subprojects {
             }
         }
     }
-    
 }
 
 defaultTasks 'build'

--- a/publish.gradle
+++ b/publish.gradle
@@ -3,7 +3,7 @@ apply plugin: 'signing'
 
 publishing {
     publications {
-        mavenJava(MavenPublication) {
+        all {
             pom {
                 url = 'https://github.com/xenit-eu/dynamic-extensions-for-alfresco'
                 name = "dynamic-extensions-for-alfresco-" + project.name
@@ -46,9 +46,11 @@ publishing {
     }
 }
 
-signing {
-    required { !version.endsWith('SNAPSHOT') && gradle.taskGraph.hasTask("publish") }
-    sign publishing.publications.mavenJava
+afterEvaluate {
+    signing {
+        required { !version.endsWith('SNAPSHOT') && gradle.taskGraph.hasTask("publish") }
+        sign publishing.publications.findAll {}.toArray(new Publication[0])
+    }
 }
 
 gradle.taskGraph.whenReady { graph ->


### PR DESCRIPTION
`eu.xenit.de` plugin was publish with incorrect POM:
`Invalid POM: /eu/xenit/de/eu.xenit.de.gradle.plugin/2.0.0/eu.xenit.de.gradle.plugin-2.0.0.pom: Project name missing, Project description missing, Project URL missing, License information missing, SCM URL missing, Developer information missing`

& the artifacts were nog signed.

This commit should fix this.