### PR TITLE
Include integration testing bundle to reproduce 263

### DIFF
--- a/documentation/Extension_Point_Behaviors.md
+++ b/documentation/Extension_Point_Behaviors.md
@@ -23,7 +23,7 @@ Also we can override when the policy should be triggered by setting the even att
 * COMMIT:  triggered from Spring commit listener, before DB commit
 * ALL: both
 
-A more complex example can be found at https://github.com/xenit-eu/example-dynamic-extension/blob/master/src/main/java/com/github/dynamicextensionsalfresco/examples/ExampleBehaviour.java.
+A more complex example can be found at https://github.com/xenit-eu/example-dynamic-extension/blob/master/gradle-with-plugin/src/main/java/eu/xenit/de/example/ExampleBehaviour.java.
 
 # Behaviour troubleshooting
 

--- a/documentation/Extension_Point_Content_Model.md
+++ b/documentation/Extension_Point_Content_Model.md
@@ -4,7 +4,7 @@ Dynamic Extensions provides a convenient way of registering custom content model
 
 To have XML content models registered automatically, place them in this location in your extension:
 
-<code>/META-INF/alfresco/models</code> <a href="https://github.com/xenit-eu/example-dynamic-extension/tree/master/src/main/resources/META-INF/alfresco/models">See example project</a>
+<code>/META-INF/alfresco/models</code> <a href="https://github.com/xenit-eu/example-dynamic-extension/tree/master/gradle-with-plugin/src/main/resources/META-INF/alfresco/models">See example project</a>
 
 When Dynamic Extensions installs an extension it scans for the presence of XML files in this folder and registers/updates the content models with the Data Dictionary. Uninstalling an extension does not remove the model as this would cause the model to disappear during restarts.
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -56,6 +56,8 @@ configure(subprojects.findAll { it.name.startsWith("alfresco-") }) {
             // Workaround for https://issues.alfresco.com/jira/browse/MNT-20557
             alfrescoAmp "eu.xenit.alfresco:alfresco-hotfix-MNT-20557:1.0.1@amp"
         }
+
+        alfrescoDE project(':integration-tests:test-bundle')
         
         baseShareWar "${shareBaseWar}"
     }

--- a/integration-tests/src/test/java/eu/xenit/dynamicextensionsalfresco/BehaviourTest.java
+++ b/integration-tests/src/test/java/eu/xenit/dynamicextensionsalfresco/BehaviourTest.java
@@ -1,0 +1,24 @@
+package eu.xenit.dynamicextensionsalfresco;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.Test;
+
+/**
+ * Integration tests for behaviors, making use of the '/behaviours/...' endpoints of the 'test-bundle'
+ */
+public class BehaviourTest extends RestAssuredTest {
+
+    @Test
+    public void testBehaviour_OnCreateNodePolicy() {
+        given()
+                .log().ifValidationFails()
+                .when()
+                .get("s/dynamic-extensions/testing/behaviours/OnCreateNodePolicy")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .body(equalTo("\"TestBehaviour successfully processed\""));
+    }
+}

--- a/integration-tests/src/test/java/eu/xenit/dynamicextensionsalfresco/BehaviourTest.java
+++ b/integration-tests/src/test/java/eu/xenit/dynamicextensionsalfresco/BehaviourTest.java
@@ -22,7 +22,7 @@ public class BehaviourTest extends RestAssuredTest {
         given()
                 .log().ifValidationFails()
                 .when()
-                .get("s/dynamic-extensions/testing/behaviours/OnCreateNodePolicy")
+                .post("s/dynamic-extensions/testing/behaviours/OnCreateNodePolicy")
                 .then()
                 .log().ifValidationFails()
                 .statusCode(200)

--- a/integration-tests/src/test/java/eu/xenit/dynamicextensionsalfresco/BehaviourTest.java
+++ b/integration-tests/src/test/java/eu/xenit/dynamicextensionsalfresco/BehaviourTest.java
@@ -4,14 +4,21 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Integration tests for behaviors, making use of the '/behaviours/...' endpoints of the 'test-bundle'
+ * Integration tests for behaviors, making use of the '/behaviours/...' endpoints which are defined in the
+ * 'test-bundle'
  */
 public class BehaviourTest extends RestAssuredTest {
 
+    private static final Logger logger = LoggerFactory.getLogger(BehaviourTest.class);
+
     @Test
     public void testBehaviour_OnCreateNodePolicy() {
+        logger.info("Test scenario: adding a property to a node using an annotated 'OnCreateNodePolicy' behaviour");
+
         given()
                 .log().ifValidationFails()
                 .when()

--- a/integration-tests/test-bundle/build.gradle
+++ b/integration-tests/test-bundle/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+    id 'eu.xenit.alfresco' version "0.2.0"
+}
+
+apply plugin: 'java'
+apply plugin: 'biz.aQute.bnd.builder'
+
+// Actual integration tests are executed in the parent project
+test.enabled = false
+
+dependencies {
+    compileOnly enforcedPlatform("eu.xenit.alfresco:alfresco-community-bom:5.0.d")
+
+    alfrescoProvided project(':annotations')
+    alfrescoProvided project(':webscripts')
+
+    alfrescoProvided('org.alfresco:alfresco-repository') { transitive = false }
+    alfrescoProvided('org.alfresco:alfresco-data-model') { transitive = false }
+    alfrescoProvided('org.alfresco:alfresco-core') { transitive = false }
+    alfrescoProvided('org.springframework:spring-core') { transitive = false }
+    alfrescoProvided('org.springframework:spring-beans') { transitive = false }
+    alfrescoProvided('org.springframework:spring-context') { transitive = false }
+    alfrescoProvided('org.springframework:spring-web') { transitive = false }
+
+    alfrescoProvided('org.slf4j:slf4j-api')
+}
+
+jar {
+    bnd(
+            'Alfresco-Dynamic-Extension': 'true',
+            'Bundle-Description': 'Bundle for integration testing purposes',
+            'Alfresco-Spring-Configuration': 'eu.xenit.de.testing',
+            'DynamicImport-Package': '*'
+    )
+}
+

--- a/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/Constants.java
+++ b/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/Constants.java
@@ -1,0 +1,12 @@
+package eu.xenit.de.testing;
+
+public class Constants {
+
+    private Constants() {
+        // private ctor to hide implicit public one
+    }
+
+    public static final String TEST_WEBSCRIPTS_FAMILY = "Test WebScripts";
+    public static final String TEST_WEBSCRIPTS_BASE_URI = "/dynamic-extensions/testing";
+
+}

--- a/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/Model.java
+++ b/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/Model.java
@@ -1,0 +1,10 @@
+package eu.xenit.de.testing;
+
+import org.alfresco.service.namespace.QName;
+
+public class Model {
+
+    public static final QName TYPE_TESTDOCUMENT = QName.createQName("test.model", "document");
+    public static final QName PROP_TESTBEHAVIOURPROPERTY = QName.createQName("test.model", "testBehaviourProperty");
+
+}

--- a/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/behaviours/TestBehaviour.java
+++ b/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/behaviours/TestBehaviour.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Behaviour("test:document")
+@SuppressWarnings("unused")
 public class TestBehaviour implements OnCreateNodePolicy {
 
     private static final Logger logger = LoggerFactory.getLogger(TestBehaviour.class);

--- a/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/behaviours/TestBehaviour.java
+++ b/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/behaviours/TestBehaviour.java
@@ -1,0 +1,33 @@
+package eu.xenit.de.testing.behaviours;
+
+import com.github.dynamicextensionsalfresco.behaviours.annotations.Behaviour;
+import com.github.dynamicextensionsalfresco.behaviours.annotations.ClassPolicy;
+import eu.xenit.de.testing.Model;
+import org.alfresco.repo.node.NodeServicePolicies.OnCreateNodePolicy;
+import org.alfresco.service.cmr.repository.ChildAssociationRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@Behaviour("test:document")
+public class TestBehaviour implements OnCreateNodePolicy {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestBehaviour.class);
+
+    @Autowired
+    private NodeService nodeService;
+
+    @Override
+    @ClassPolicy
+    public void onCreateNode(ChildAssociationRef childAssocRef) {
+
+        nodeService.setProperty(
+                childAssocRef.getChildRef(),
+                Model.PROP_TESTBEHAVIOURPROPERTY,
+                "TestBehaviour successfully processed");
+
+    }
+}

--- a/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/behaviours/TestBehaviourWebScript.java
+++ b/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/behaviours/TestBehaviourWebScript.java
@@ -1,0 +1,92 @@
+package eu.xenit.de.testing.behaviours;
+
+import static eu.xenit.de.testing.Constants.TEST_WEBSCRIPTS_BASE_URI;
+import static eu.xenit.de.testing.Constants.TEST_WEBSCRIPTS_FAMILY;
+
+import com.github.dynamicextensionsalfresco.webscripts.annotations.Transaction;
+import com.github.dynamicextensionsalfresco.webscripts.annotations.Uri;
+import com.github.dynamicextensionsalfresco.webscripts.annotations.WebScript;
+import eu.xenit.de.testing.Model;
+import java.util.List;
+import org.alfresco.model.ContentModel;
+import org.alfresco.repo.security.authentication.AuthenticationUtil;
+import org.alfresco.repo.transaction.RetryingTransactionHelper;
+import org.alfresco.service.cmr.model.FileFolderService;
+import org.alfresco.service.cmr.repository.ChildAssociationRef;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.cmr.repository.StoreRef;
+import org.alfresco.service.namespace.QName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+@WebScript(families = TEST_WEBSCRIPTS_FAMILY, baseUri = TEST_WEBSCRIPTS_BASE_URI + "/behaviours")
+public class TestBehaviourWebScript {
+
+    private RetryingTransactionHelper retryingTransactionHelper;
+    private NodeService nodeService;
+    private FileFolderService fileFolderService;
+
+    private NodeRef testFolder;
+
+    @Autowired
+    public TestBehaviourWebScript(NodeService nodeService,
+            FileFolderService fileFolderService,
+            RetryingTransactionHelper retryingTransactionHelper) {
+        this.nodeService = nodeService;
+        this.fileFolderService = fileFolderService;
+        this.retryingTransactionHelper = retryingTransactionHelper;
+
+        AuthenticationUtil.runAsSystem(() -> testFolder = createOrResetTestFolder());
+    }
+
+
+    @Uri("/OnCreateNodePolicy")
+    @Transaction
+    public ResponseEntity<String> testBehaviour_OnCreateNodePolicy() {
+
+        final NodeRef createdNode = retryingTransactionHelper.doInTransaction(
+                () -> nodeService.createNode(
+                        testFolder,
+                        ContentModel.ASSOC_CONTAINS,
+                        QName.createQName("{test.model}", "testBehaviour_OnCreateNodePolicy"),
+                        Model.TYPE_TESTDOCUMENT),
+                false,
+                true).getChildRef();
+
+        if (createdNode == null) {
+            return new ResponseEntity<>("Test node was not created correctly", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        final String testBehaviourProperty = (String) nodeService
+                .getProperty(createdNode, Model.PROP_TESTBEHAVIOURPROPERTY);
+
+        return new ResponseEntity<>(testBehaviourProperty, HttpStatus.OK);
+
+    }
+
+    private NodeRef createOrResetTestFolder() {
+        final NodeRef companyHome = getCompanyHome();
+
+        final NodeRef existingTestFolder = fileFolderService.searchSimple(companyHome, "Behaviours");
+
+        if (existingTestFolder != null) {
+            fileFolderService.delete(existingTestFolder);
+        }
+
+        return fileFolderService.create(companyHome, "Behaviours", ContentModel.TYPE_FOLDER).getNodeRef();
+    }
+
+    private NodeRef getCompanyHome() {
+        StoreRef storeRef = new StoreRef("workspace", "SpacesStore");
+        final NodeRef rootNodeRef = nodeService.getRootNode(storeRef);
+        QName qname = QName.createQName("http://www.alfresco.org/model/application/1.0", "company_home");
+        List<ChildAssociationRef> assocRefs = this.nodeService
+                .getChildAssocs(rootNodeRef, ContentModel.ASSOC_CHILDREN, qname);
+        return assocRefs.get(0).getChildRef();
+    }
+
+}

--- a/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/behaviours/TestBehaviourWebScript.java
+++ b/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/behaviours/TestBehaviourWebScript.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @WebScript(families = TEST_WEBSCRIPTS_FAMILY, baseUri = TEST_WEBSCRIPTS_BASE_URI + "/behaviours")
+@SuppressWarnings("unused")
 public class TestBehaviourWebScript {
 
     private RetryingTransactionHelper retryingTransactionHelper;

--- a/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/behaviours/TestBehaviourWebScript.java
+++ b/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/behaviours/TestBehaviourWebScript.java
@@ -3,6 +3,7 @@ package eu.xenit.de.testing.behaviours;
 import static eu.xenit.de.testing.Constants.TEST_WEBSCRIPTS_BASE_URI;
 import static eu.xenit.de.testing.Constants.TEST_WEBSCRIPTS_FAMILY;
 
+import com.github.dynamicextensionsalfresco.webscripts.annotations.HttpMethod;
 import com.github.dynamicextensionsalfresco.webscripts.annotations.Transaction;
 import com.github.dynamicextensionsalfresco.webscripts.annotations.Uri;
 import com.github.dynamicextensionsalfresco.webscripts.annotations.WebScript;
@@ -45,8 +46,7 @@ public class TestBehaviourWebScript {
     }
 
 
-    @Uri("/OnCreateNodePolicy")
-    @Transaction
+    @Uri(value = "/OnCreateNodePolicy", method = HttpMethod.POST)
     public ResponseEntity<String> testBehaviour_OnCreateNodePolicy() {
 
         final NodeRef createdNode = retryingTransactionHelper.doInTransaction(

--- a/integration-tests/test-bundle/src/main/resources/META-INF/alfresco/models/test-model.xml
+++ b/integration-tests/test-bundle/src/main/resources/META-INF/alfresco/models/test-model.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model name="test:testModel" xmlns="http://www.alfresco.org/model/dictionary/1.0">
+
+    <description>Metadata model for testing purposes</description>
+    <author>Daan Kerkhofs</author>
+    <version>1.0</version>
+
+    <imports>
+        <import uri="http://www.alfresco.org/model/dictionary/1.0" prefix="d"/>
+        <import uri="http://www.alfresco.org/model/content/1.0" prefix="cm"/>
+    </imports>
+
+    <namespaces>
+        <namespace uri="test.model" prefix="test"/>
+    </namespaces>
+
+    <types>
+        <type name="test:document">
+            <title>Test document</title>
+            <parent>cm:content</parent>
+        </type>
+    </types>
+
+    <aspects>
+        <aspect name="test:testBehaviourAspect">
+            <title>Test aspect</title>
+            <properties>
+                <property name="test:testBehaviourProperty">
+                    <title>Test Behaviour Property</title>
+                    <description>Will be filled by the TestBehaviour</description>
+                    <type>d:text</type>
+                    <mandatory>false</mandatory>
+                </property>
+            </properties>
+        </aspect>
+    </aspects>
+
+</model>

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,6 +32,7 @@ alfrescoDependentModules.each { moduleId ->
 }
 
 include 'integration-tests'
+include 'integration-tests:test-bundle'
 include 'integration-tests:alfresco-60'
 include 'integration-tests:alfresco-61'
 Versions.supportedAlfrescoVersions.each { alfrescoVersion ->


### PR DESCRIPTION
1. Created a test-bundle, which is a DE bundle that will be installed into Alfresco during the integration testing. 
The idea is that several DE functionalities can be added to this bundle & we can verify this functionalities using webscripts. 

2. To get better understanding in #263, I added this scenario to the test bundle and was able to reproduce the behavior. 
I also verified that adding the `DynamicImport-Package: *` indeed solves the problem.