### PR TITLE
Update docker images used for integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ jdk:
 services:
 - docker
 
+install: ./gradlew assemble -i
+
 script:
 - ./gradlew test
 - if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then ./gradlew integrationTest; fi

--- a/integration-tests/alfresco-60/overload.gradle
+++ b/integration-tests/alfresco-60/overload.gradle
@@ -1,7 +1,0 @@
-ext {
-    alfrescoBaseWar = 'org.alfresco:content-services-community:6.0.7-ga@war'
-    alfrescoBaseImage = 'alfresco/alfresco-content-repository-community:6.0.7-ga'
-    shareBaseWar = 'org.alfresco:share:6.0.c@war'
-    
-    postgresImage = 'postgres:10.1'
-}

--- a/integration-tests/alfresco-61/overload.gradle
+++ b/integration-tests/alfresco-61/overload.gradle
@@ -1,7 +1,0 @@
-ext {
-    alfrescoBaseWar = 'org.alfresco:content-services-community:6.1.2-ga@war'
-    alfrescoBaseImage = 'alfresco/alfresco-content-repository-community:6.1.2-ga'
-    shareBaseWar = 'org.alfresco:share:6.1.0@war'
-
-    postgresImage = 'postgres:10.1'
-}

--- a/integration-tests/alfresco-community-50/overload.gradle
+++ b/integration-tests/alfresco-community-50/overload.gradle
@@ -1,0 +1,6 @@
+ext {
+    alfrescoBaseWar = 'org.alfresco:alfresco:5.0.d@war'
+    alfrescoBaseImage = 'xeniteu/alfresco-repository-community:5.0.d'
+    
+    postgresImage = 'postgres:10.1'
+}

--- a/integration-tests/alfresco-community-51/overload.gradle
+++ b/integration-tests/alfresco-community-51/overload.gradle
@@ -1,0 +1,6 @@
+ext {
+    alfrescoBaseWar = 'org.alfresco:alfresco:5.1.e@war'
+    alfrescoBaseImage = 'xeniteu/alfresco-repository-community:5.1.e'
+    
+    postgresImage = 'postgres:10.1'
+}

--- a/integration-tests/alfresco-community-52/overload.gradle
+++ b/integration-tests/alfresco-community-52/overload.gradle
@@ -1,0 +1,6 @@
+ext {
+    alfrescoBaseWar = 'org.alfresco:alfresco-platform:5.2.g@war'
+    alfrescoBaseImage = 'xeniteu/alfresco-repository-community:5.2.g'
+    
+    postgresImage = 'postgres:10.1'
+}

--- a/integration-tests/alfresco-community-60/overload.gradle
+++ b/integration-tests/alfresco-community-60/overload.gradle
@@ -1,0 +1,6 @@
+ext {
+    alfrescoBaseWar = 'org.alfresco:content-services-community:6.0.7-ga@war'
+    alfrescoBaseImage = 'xeniteu/alfresco-repository-community:6.0.7-ga'
+    
+    postgresImage = 'postgres:10.1'
+}

--- a/integration-tests/alfresco-community-61/overload.gradle
+++ b/integration-tests/alfresco-community-61/overload.gradle
@@ -1,0 +1,6 @@
+ext {
+    alfrescoBaseWar = 'org.alfresco:content-services-community:6.1.2-ga@war'
+    alfrescoBaseImage = 'xeniteu/alfresco-repository-community:6.1.2-ga'
+
+    postgresImage = 'postgres:10.1'
+}

--- a/integration-tests/alfresco-enterprise-50/overload.gradle
+++ b/integration-tests/alfresco-enterprise-50/overload.gradle
@@ -1,7 +1,6 @@
 ext {
     alfrescoBaseWar = 'org.alfresco:alfresco-enterprise:5.0.4@war'
-    alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise:5.0.4'
-    shareBaseWar = 'org.alfresco:share:5.0.4@war'
+    alfrescoBaseImage = 'hub.xenit.eu/alfresco-repository-enterprise:5.0.4'
     
     postgresImage = 'postgres:10.1'
 }

--- a/integration-tests/alfresco-enterprise-51/overload.gradle
+++ b/integration-tests/alfresco-enterprise-51/overload.gradle
@@ -1,7 +1,6 @@
 ext {
     alfrescoBaseWar = 'org.alfresco:alfresco-enterprise:5.1.5@war'
-    alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise:5.1.5'
-    shareBaseWar = 'org.alfresco:share:5.1.5@war'
+    alfrescoBaseImage = 'hub.xenit.eu/alfresco-repository-enterprise:5.1.5'
     
     postgresImage = 'postgres:10.1'
 }

--- a/integration-tests/alfresco-enterprise-52/overload.gradle
+++ b/integration-tests/alfresco-enterprise-52/overload.gradle
@@ -1,7 +1,6 @@
 ext {
     alfrescoBaseWar = 'org.alfresco:alfresco-enterprise:5.2.5@war'
-    alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise:5.2.5'
-    shareBaseWar = 'org.alfresco:share:5.2.5@war'
+    alfrescoBaseImage = 'hub.xenit.eu/alfresco-repository-enterprise:5.2.5'
     
     postgresImage = 'postgres:10.1'
 }

--- a/integration-tests/alfresco-enterprise-60/overload.gradle
+++ b/integration-tests/alfresco-enterprise-60/overload.gradle
@@ -1,7 +1,6 @@
 ext {
     alfrescoBaseWar = 'org.alfresco:content-services:6.0.1.2@war'
-    alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise:6.0.1.2'
-    shareBaseWar = 'org.alfresco:share:6.0.1.1@war'
+    alfrescoBaseImage = 'hub.xenit.eu/alfresco-repository-enterprise:6.0.1.2'
     
     postgresImage = 'postgres:10.1'
 }

--- a/integration-tests/alfresco-enterprise-61/overload.gradle
+++ b/integration-tests/alfresco-enterprise-61/overload.gradle
@@ -1,7 +1,6 @@
 ext {
     alfrescoBaseWar = 'org.alfresco:content-services:6.1.0.3@war'
-    alfrescoBaseImage = 'alfresco/alfresco-content-repository:6.1.0.3'
-    shareBaseWar = 'org.alfresco:share:6.1.0@war'
+    alfrescoBaseImage = 'hub.xenit.eu/alfresco-repository-enterprise:6.1.0.3'
 
     postgresImage = 'postgres:10.1'
 }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -58,8 +58,6 @@ configure(subprojects.findAll { it.name.startsWith("alfresco-") }) {
         }
 
         alfrescoDE project(':integration-tests:test-bundle')
-        
-        baseShareWar "${shareBaseWar}"
     }
     
     dockerAlfresco {

--- a/settings.gradle
+++ b/settings.gradle
@@ -33,8 +33,7 @@ alfrescoDependentModules.each { moduleId ->
 
 include 'integration-tests'
 include 'integration-tests:test-bundle'
-include 'integration-tests:alfresco-60'
-include 'integration-tests:alfresco-61'
 Versions.supportedAlfrescoVersions.each { alfrescoVersion ->
+    include "integration-tests:alfresco-community-${alfrescoVersion}"
     include "integration-tests:alfresco-enterprise-${alfrescoVersion}"
 }


### PR DESCRIPTION
Xenit Docker images have been open sourced!
https://github.com/xenit-eu/docker-alfresco

This PR updates the images used for integration testing.