### PR TITLE
Disable integration tests on Travis for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ install: ./gradlew assemble -i
 
 script:
 - ./gradlew test
-- if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then ./gradlew integrationTest; fi
-- if [ "$TRAVIS_BRANCH" = "master" ]; then ./gradlew integrationTest; fi
-- if [ "$TRAVIS_BRANCH" = "release" ]; then ./gradlew integrationTest; fi
 
 before_cache:
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Dynamic Extensions for Alfresco
 
 [![Apache License 2](https://img.shields.io/badge/license-Apache%202-blue.svg)](LICENSE)
-[![Build Status](https://travis-ci.org/xenit-eu/dynamic-extensions-for-alfresco.svg)](https://travis-ci.org/xenit-eu/dynamic-extensions-for-alfresco)
+[![Travis Build Status](https://img.shields.io/travis/xenit-eu/dynamic-extensions-for-alfresco?label=Travis)](https://travis-ci.org/xenit-eu/dynamic-extensions-for-alfresco)
+[![Jenkins Build Status](https://jenkins-2.xenit.eu/buildStatus/icon?job=Xenit+Github%2Fdynamic-extensions-for-alfresco%2Fmaster&subject=Jenkins)](https://jenkins-2.xenit.eu/job/Xenit%20Github/job/dynamic-extensions-for-alfresco/job/master/)
 [![Maven Central](https://img.shields.io/maven-central/v/eu.xenit/alfresco-dynamic-extensions-repo-61.svg?maxAge=300)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22eu.xenit%22%20AND%20a%3A%22alfresco-dynamic-extensions-repo-*%22)
 
 Add OSGi based hot-deploy functionality and Spring annotation based configuration to Alfresco.
@@ -59,13 +60,13 @@ the [Alfresco Docker Gradle Plugins](https://github.com/xenit-eu/alfresco-docker
 
 Dynamic Extensions is systematically integration-tested against:
 
-* Alfresco Enterprise 6.1
-* Alfresco Community 6.1
-* Alfresco Enterprise 6.0
-* Alfresco Community 6.0
-* Alfresco Enterprise 5.2
-* Alfresco Enterprise 5.1
-* Alfresco Enterprise 5.0
+* Alfresco Enterprise & Community 6.1
+* Alfresco Enterprise & Community 6.0
+* Alfresco Enterprise & Community 5.2
+* Alfresco Enterprise & Community 5.1
+* Alfresco Enterprise & Community 5.0
+
+> Integration tests are currently only executed on our private Jenkins build server. 
 
 #### Known Alfresco issues that impact Dynamic Extensions
 <details><summary>Alfresco 6.1 - wrong version of 'Commons annotations' used</summary>When using DE on Alfresco 6.1, it is possible that it fails to startup due to following error:


### PR DESCRIPTION
All integration testing is done on our private Jenkins server as well. 

On the long term, we'll need to find a solution for Travis build exceeding the time limit when integration testing against multiple Alfresco versions. This is a short term solution to de-block the situation.