### PR TITLE
Fixes 197 and 275 deploy models in nested transaction

### DIFF
--- a/alfresco-integration/src/main/java/com/github/dynamicextensionsalfresco/models/RepositoryModelRegistrar.java
+++ b/alfresco-integration/src/main/java/com/github/dynamicextensionsalfresco/models/RepositoryModelRegistrar.java
@@ -52,7 +52,7 @@ public class RepositoryModelRegistrar extends AbstractModelRegistrar {
                                 modelResource.getName(), e);
                     }
                     return null;
-                },false,false);
+                },false,true);
                 } catch(Exception e){
                     logger.error("tx error", e);
                 }

--- a/alfresco-integration/src/main/java/com/github/dynamicextensionsalfresco/models/RepositoryModelRegistrar.java
+++ b/alfresco-integration/src/main/java/com/github/dynamicextensionsalfresco/models/RepositoryModelRegistrar.java
@@ -4,7 +4,6 @@ package com.github.dynamicextensionsalfresco.models;
 import com.github.dynamicextensionsalfresco.resources.ResourceHelper;
 import org.alfresco.repo.dictionary.RepositoryLocation;
 import org.alfresco.repo.security.authentication.AuthenticationUtil;
-import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.service.cmr.admin.RepoAdminService;
 import org.alfresco.service.cmr.repository.NodeService;
 import org.alfresco.service.transaction.TransactionService;
@@ -13,9 +12,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Register models in the repository as cm:dictionaryModel's using the [RepoAdminService].
+ * Register models in the repository as cm:dictionaryModel's using the {@link RepoAdminService}.
  */
 public class RepositoryModelRegistrar extends AbstractModelRegistrar {
+
+    private Logger logger = LoggerFactory.getLogger(RepositoryModelRegistrar.class);
+
     @Autowired
     public RepositoryLocation customModelsRepositoryLocation;
     @Autowired
@@ -26,7 +28,6 @@ public class RepositoryModelRegistrar extends AbstractModelRegistrar {
     public TransactionService transactionService;
     @Autowired
     public ResourceHelper resourceHelper;
-    private Logger logger = LoggerFactory.getLogger(RepositoryModelRegistrar.class);
 
     @Override
     public void unregisterModels() {
@@ -35,32 +36,27 @@ public class RepositoryModelRegistrar extends AbstractModelRegistrar {
 
     @Override
     public void registerModel(final M2ModelResource modelResource) {
-        AuthenticationUtil.runAsSystem(new AuthenticationUtil.RunAsWork<Object>() {
-            @Override
-            public Object doWork() throws Exception {
-                try {
-                    transactionService.getRetryingTransactionHelper().doInTransaction(new RetryingTransactionHelper.RetryingTransactionCallback<Object>() {
-                        @Override
-                        public Object execute() throws Throwable {
-                            try {
-                                if (resourceHelper.nodeDiffersFromResource(modelResource.getResource(), customModelsRepositoryLocation)) {
-                                    repoAdminService.deployModel(
-                                            modelResource.getResource().getInputStream(),
-                                            modelResource.getResource().getFilename());
-                                    logger.debug("Registered model ${modelResource.name}");
-                                }
-                            }
-                            catch (Exception e){
-                                logger.error("Failed to deploy M2Model ${modelResource.name} as a cm:dictionaryModel", e);
-                            }
-                            return null;
+        AuthenticationUtil.runAsSystem(() -> {
+            try {
+                transactionService.getRetryingTransactionHelper().doInTransaction(() -> {
+                    try {
+                        if (resourceHelper.nodeDiffersFromResource(modelResource.getResource(), customModelsRepositoryLocation)) {
+                            repoAdminService.deployModel(
+                                    modelResource.getResource().getInputStream(),
+                                    modelResource.getResource().getFilename());
+                            logger.debug("Registered model {}", modelResource.getName());
                         }
-                    },false,false);
-                    } catch(Exception e){
-                        logger.error("tx error", e);
+                    }
+                    catch (Exception e){
+                        logger.error("Failed to deploy M2Model {} as a cm:dictionaryModel",
+                                modelResource.getName(), e);
                     }
                     return null;
+                },false,false);
+                } catch(Exception e){
+                    logger.error("tx error", e);
                 }
+                return null;
             });
         }
     }

--- a/integration-tests/src/test/java/eu/xenit/dynamicextensionsalfresco/BehaviourTest.java
+++ b/integration-tests/src/test/java/eu/xenit/dynamicextensionsalfresco/BehaviourTest.java
@@ -2,6 +2,7 @@ package eu.xenit.dynamicextensionsalfresco;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.isEmptyString;
 
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -17,7 +18,8 @@ public class BehaviourTest extends RestAssuredTest {
 
     @Test
     public void testBehaviour_OnCreateNodePolicy() {
-        logger.info("Test scenario: adding a property to a node using an annotated 'OnCreateNodePolicy' behaviour");
+        logger.info("Test scenario: check that the 'OnCreateNodePolicy' behaviour is triggered when creating an "
+                + "applicable node");
 
         given()
                 .log().ifValidationFails()
@@ -27,5 +29,20 @@ public class BehaviourTest extends RestAssuredTest {
                 .log().ifValidationFails()
                 .statusCode(200)
                 .body(equalTo("\"TestBehaviour successfully processed\""));
+    }
+
+    @Test
+    public void testBehaviour_OnCreateNodePolicy_notTriggeredIfTypeNotApplicable() {
+        logger.info("Test scenario: check that the 'OnCreateNodePolicy' behaviour is not triggered when creating a "
+                + "node that is not applicable");
+
+        given()
+                .log().ifValidationFails()
+                .when()
+                .post("s/dynamic-extensions/testing/behaviours/OnCreateNodePolicyNotTriggeredIfTypeNotApplicable")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .body(isEmptyString());
     }
 }

--- a/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/behaviours/TestBehaviour.java
+++ b/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/behaviours/TestBehaviour.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-@Behaviour("test:document")
+@Behaviour
 @SuppressWarnings("unused")
 public class TestBehaviour implements OnCreateNodePolicy {
 
@@ -22,7 +22,7 @@ public class TestBehaviour implements OnCreateNodePolicy {
     private NodeService nodeService;
 
     @Override
-    @ClassPolicy
+    @ClassPolicy("test:document")
     public void onCreateNode(ChildAssociationRef childAssocRef) {
 
         nodeService.setProperty(

--- a/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/behaviours/TestBehaviourWebScript.java
+++ b/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/behaviours/TestBehaviourWebScript.java
@@ -4,7 +4,6 @@ import static eu.xenit.de.testing.Constants.TEST_WEBSCRIPTS_BASE_URI;
 import static eu.xenit.de.testing.Constants.TEST_WEBSCRIPTS_FAMILY;
 
 import com.github.dynamicextensionsalfresco.webscripts.annotations.HttpMethod;
-import com.github.dynamicextensionsalfresco.webscripts.annotations.Transaction;
 import com.github.dynamicextensionsalfresco.webscripts.annotations.Uri;
 import com.github.dynamicextensionsalfresco.webscripts.annotations.WebScript;
 import eu.xenit.de.testing.Model;
@@ -48,13 +47,26 @@ public class TestBehaviourWebScript {
 
     @Uri(value = "/OnCreateNodePolicy", method = HttpMethod.POST)
     public ResponseEntity<String> testBehaviour_OnCreateNodePolicy() {
+        return createTestNodeAndReturnTestBehaviourProperty(
+                Model.TYPE_TESTDOCUMENT,
+                "testBehaviour_OnCreateNodePolicy");
+    }
 
+
+    @Uri(value = "/OnCreateNodePolicyNotTriggeredIfTypeNotApplicable", method = HttpMethod.POST)
+    public ResponseEntity<String> testBehaviour_OnCreateNodePolicy_notTriggeredIfTypeNotApplicable() {
+        return createTestNodeAndReturnTestBehaviourProperty(
+                ContentModel.TYPE_CONTENT,
+                "testBehaviour_OnCreateNodePolicy_notTriggeredIfTypeNotApplicable");
+    }
+
+    private ResponseEntity<String> createTestNodeAndReturnTestBehaviourProperty(final QName type, final String name) {
         final NodeRef createdNode = retryingTransactionHelper.doInTransaction(
                 () -> nodeService.createNode(
                         testFolder,
                         ContentModel.ASSOC_CONTAINS,
-                        QName.createQName("{test.model}", "testBehaviour_OnCreateNodePolicy"),
-                        Model.TYPE_TESTDOCUMENT),
+                        QName.createQName("{test.model}", name),
+                        type),
                 false,
                 true).getChildRef();
 
@@ -66,7 +78,6 @@ public class TestBehaviourWebScript {
                 .getProperty(createdNode, Model.PROP_TESTBEHAVIOURPROPERTY);
 
         return new ResponseEntity<>(testBehaviourProperty, HttpStatus.OK);
-
     }
 
     private NodeRef createOrResetTestFolder() {

--- a/integration-tests/test-bundle/src/main/resources/META-INF/alfresco/models/another-test-model.xml
+++ b/integration-tests/test-bundle/src/main/resources/META-INF/alfresco/models/another-test-model.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model name="another:anotherTestModel" xmlns="http://www.alfresco.org/model/dictionary/1.0">
+
+    <description>Metadata model for testing purposes, this model depends on the test-model</description>
+    <author>Daan Kerkhofs</author>
+    <version>1.0</version>
+
+    <imports>
+        <import uri="test.model" prefix="test"/>
+    </imports>
+
+    <namespaces>
+        <namespace uri="another.test.model" prefix="another"/>
+    </namespaces>
+
+    <types>
+        <type name="another:document">
+            <title>Another document type</title>
+            <description>Type is child of test:document</description>
+            <parent>test:document</parent>
+        </type>
+    </types>
+
+</model>


### PR DESCRIPTION
#### Changes

* Added integration tests to reproduce issue #197 and #275. 
* `RepositoryModelRegistrar#registerModel(...)` now deploys the model in a nested transaction. 

#### Description of the root cause

The DE `RepositoryModelRegistrar` is used to deploy and active new models in the `Data Dicationary/Models` location. This is done by using Alfresco's `RepoAdminService#deployModel(...)` method. 

However the `deployModel(...)` method only adds the model model to the `Data Dictionary/Models` folders and activates the model. Having a look at [Alfresco's `DictionaryModelType#beforeCommit(boolean readOnly)` method](https://github.com/Alfresco/alfresco-repository/blob/master/src/main/java/org/alfresco/repo/dictionary/DictionaryModelType.java#L564), we can see that the actual compiling and validating of the model is not done immediately but before the transaction commits. 
This causes issues when there are things deployed alongside the model that actually depend on the model. 

Moving the deployment of the model to a nested transaction should fix this issue, because that the `beforeCommit(...)` will already be triggered  when continuing to deploy other models / behaviors. 

#### Discussion

Is this fix feasible? Can deploying the models in a nested transaction have possible side effects? (E.g. an inconsistent state where some stuff is deployed and some isn't). 
Feel free to play the devil's advocate. 

Fixes #197, fixes #275