### PR TITLE
Remove lambda in doLast, improves build cache, fixes #265

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Version template:
 # Dynamic Extensions For Alfresco Changelog
 
 ## [2.0.3] - UNRELEASED
+### Fixed
+* [#265](https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/265) `DeBundle` task failing to use build cache
 
 ## [2.0.2] - 2019-10-08
 ### Fixed

--- a/gradle-plugin/src/main/java/com/github/dynamicextensionsalfresco/gradle/tasks/DeBundleTaskConvention.java
+++ b/gradle-plugin/src/main/java/com/github/dynamicextensionsalfresco/gradle/tasks/DeBundleTaskConvention.java
@@ -4,6 +4,7 @@ import aQute.bnd.gradle.BundleTaskConvention;
 import aQute.bnd.osgi.Constants;
 import com.github.dynamicextensionsalfresco.gradle.internal.BndHandler;
 import org.gradle.api.Action;
+import org.gradle.api.Task;
 import org.gradle.api.tasks.bundling.Jar;
 
 /**
@@ -24,7 +25,13 @@ public class DeBundleTaskConvention {
         this.task = task;
         bndConvention = new BundleTaskConvention(task);
         task.getConvention().getPlugins().put("_bundle_bnd", bndConvention);
-        task.doLast("buildDeBundle", t -> buildDeBundle());
+        // This is an anonymous inner class instead of a lambda because of a gradle issue where lambdas break up-to-date checks
+        task.doLast("buildDeBundle", new Action<Task>() {
+            @Override
+            public void execute(Task task) {
+                buildDeBundle();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
Gradle has stopped doing up-to-date checks on tasks that use Java lambdas. Using anonymous inner classes instead allows the up-to-date checks to work again.

See https://github.com/gradle/gradle/issues/5510#issuecomment-416860213

<!--- Provide a general summary of your changes in the Title above -->

## Description
Replace the lambda in the `DeBundle` task with an anonymous inner class that has the same functionality Java-wise but is a better target for gradle's up-to-date checks.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/265

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This improves build caching and avoids printing some warning during a build that uses DE.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`./gradlew test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the changelog.
