### PR TITLE
Added LoggingAwareExecuter interface to AnnotationBasedActionExecuter…

### DIFF
--- a/alfresco-dynamic-extensions-repo/build.gradle
+++ b/alfresco-dynamic-extensions-repo/build.gradle
@@ -46,6 +46,10 @@ subprojects {
             blueprint(project(":blueprint-integration:blueprint-integration-spring-5"))
         }
 
+        if(project.name.endsWith("-50")) {
+            ampLib(project(":polyfill:polyfill-alfresco-50")) { transitive = false }
+        }
+
         blueprint("org.eclipse.gemini.blueprint:gemini-blueprint-core:${project.ext.geminiVersion}")
         blueprint("org.eclipse.gemini.blueprint:gemini-blueprint-io:${project.ext.geminiVersion}")
 

--- a/annotations-runtime/build.gradle
+++ b/annotations-runtime/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     compileOnly("org.activiti:activiti-engine:5.7") { transitive = false }
     compileOnly("org.activiti:activiti-spring:5.7") { transitive = false }
 
+    compileOnly project(':polyfill:polyfill-alfresco-50')
+
     compileOnly 'com.google.code.findbugs:jsr305:2.0.1'
     compile 'com.google.collections:google-collections:1.0'
 

--- a/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/actions/AnnotationBasedActionExecuter.java
+++ b/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/actions/AnnotationBasedActionExecuter.java
@@ -5,6 +5,7 @@ import org.alfresco.repo.action.executer.LoggingAwareExecuter;
 import org.alfresco.service.cmr.action.Action;
 import org.alfresco.service.cmr.action.ActionDefinition;
 import org.alfresco.service.cmr.repository.NodeRef;
+import org.apache.commons.logging.Log;
 
 class AnnotationBasedActionExecuter implements ActionExecuter, LoggingAwareExecuter {
 

--- a/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/actions/AnnotationBasedActionExecuter.java
+++ b/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/actions/AnnotationBasedActionExecuter.java
@@ -1,11 +1,12 @@
 package com.github.dynamicextensionsalfresco.actions;
 
 import org.alfresco.repo.action.executer.ActionExecuter;
+import org.alfresco.repo.action.executer.LoggingAwareExecuter;
 import org.alfresco.service.cmr.action.Action;
 import org.alfresco.service.cmr.action.ActionDefinition;
 import org.alfresco.service.cmr.repository.NodeRef;
 
-class AnnotationBasedActionExecuter implements ActionExecuter {
+class AnnotationBasedActionExecuter implements ActionExecuter, LoggingAwareExecuter {
 
 	private final ActionMethodMapping mapping;
 
@@ -50,6 +51,11 @@ class AnnotationBasedActionExecuter implements ActionExecuter {
 
 	@Override
 	public boolean getTrackStatus() {
+		return false;
+	}
+
+	@Override
+	public boolean onLogException(Log logger, Throwable t, String message) {
 		return false;
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,9 @@ allprojects {
 subprojects {
     if (project.name == 'integration-tests'
         || project.parent.name == 'integration-tests'
-        || project.name == 'blueprint-integration') {
+        || project.name == 'blueprint-integration'
+        || project.name == 'polyfill'
+        || project.parent.name == 'polyfill') {
         return
     }
 

--- a/polyfill/polyfill-alfresco-50/build.gradle
+++ b/polyfill/polyfill-alfresco-50/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+    id 'java-library'
+}
+
+dependencies {
+    compileOnly 'commons-logging:commons-logging:1.2'
+}

--- a/polyfill/polyfill-alfresco-50/src/main/java/org/alfresco/repo/action/executer/LoggingAwareExecuter.java
+++ b/polyfill/polyfill-alfresco-50/src/main/java/org/alfresco/repo/action/executer/LoggingAwareExecuter.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * Alfresco Repository
+ * %%
+ * Copyright (C) 2005 - 2016 Alfresco Software Limited
+ * %%
+ * This file is part of the Alfresco software.
+ * If the software was purchased under a paid Alfresco license, the terms of
+ * the paid license agreement will prevail.  Otherwise, the software is
+ * provided under the following open source license terms:
+ *
+ * Alfresco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Alfresco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Alfresco. If not, see <http://www.gnu.org/licenses/>.
+ * #L%
+ */
+package org.alfresco.repo.action.executer;
+
+import org.apache.commons.logging.Log;
+
+public interface LoggingAwareExecuter {
+
+    /**
+     * Optional logging of errors callback for the action executer for the cases when the error might be ignored or
+     * shown in a different manner for the action
+     *
+     * @param logger the logger
+     * @param t the exception thrown
+     * @param message the proposed message that will be logged
+     * @return true if it was handled, false for default handling
+     */
+    boolean onLogException(Log logger, Throwable t, String message);
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,8 @@ include 'control-panel'
 
 include 'gradle-plugin'
 
+include 'polyfill:polyfill-alfresco-50'
+
 
 def alfrescoDependentModules =
         [


### PR DESCRIPTION
… so exceptions in alfresco actions get handled the same as in ActionExecuterAbstractBase and not throw a java.lang.ClassCastException

## Motivation and Context
When Alfresco's ActionServiceImpl method onLogException is called it tries to use the LoggingAwareExecuter interface, however it is not implemented so a  java.lang.ClassCastException is thrown instead.
By simply adding the interface to the AnnotationBasedActionExecuter with the same implementation as in ActionExecuterAbstractBase this problem is resolved and error logging is handled as normal in OOTB alfresco action.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the changelog.
