### PR TITLE
Quartz bean registration fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Version template:
 # Dynamic Extensions For Alfresco Changelog
 
 ## [2.0.4] - UNRELEASED
+### Fixed
+* [#297](https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/297) Multiple bean candidates for a Quartz' `SchedulerFactoryBean`
 
 
 ## [2.0.3] - 2020-03-12

--- a/annotations-runtime/scheduler-quartz-1/src/main/java/com/github/dynamicextensionsalfresco/schedule/quartz/QuartzTaskScheduler.java
+++ b/annotations-runtime/scheduler-quartz-1/src/main/java/com/github/dynamicextensionsalfresco/schedule/quartz/QuartzTaskScheduler.java
@@ -1,6 +1,5 @@
 package com.github.dynamicextensionsalfresco.schedule.quartz;
 
-
 import com.github.dynamicextensionsalfresco.schedule.Task;
 import com.github.dynamicextensionsalfresco.schedule.TaskConfiguration;
 import com.github.dynamicextensionsalfresco.schedule.TaskRegistration;
@@ -16,6 +15,7 @@ import org.quartz.Scheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
  * Pluggable TaskScheduler adaptor for Quartz 1 used in Alfresco 5.x
@@ -28,6 +28,7 @@ public class QuartzTaskScheduler implements TaskScheduler {
     static final String JOB_LOCK_SERVICE = "jobLockService";
 
     @Autowired
+    @Qualifier("schedulerFactory")
     private Scheduler scheduler;
 
     @Autowired

--- a/annotations-runtime/scheduler-quartz-2/src/main/java/com/github/dynamicextensionsalfresco/schedule/quartz2/Quartz2TaskScheduler.java
+++ b/annotations-runtime/scheduler-quartz-2/src/main/java/com/github/dynamicextensionsalfresco/schedule/quartz2/Quartz2TaskScheduler.java
@@ -19,6 +19,7 @@ import org.quartz.TriggerBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
  * Pluggable TaskScheduler adaptor for Quartz 2 used in Alfresco 6.x
@@ -31,6 +32,7 @@ public class Quartz2TaskScheduler implements TaskScheduler {
     static final String JOB_LOCK_SERVICE = "jobLockService";
 
     @Autowired
+    @Qualifier("schedulerFactory")
     private Scheduler scheduler;
 
     @Autowired

--- a/blueprint-integration/src/main/java/com/github/dynamicextensionsalfresco/blueprint/DynamicExtensionsApplicationContextBase.java
+++ b/blueprint-integration/src/main/java/com/github/dynamicextensionsalfresco/blueprint/DynamicExtensionsApplicationContextBase.java
@@ -553,10 +553,10 @@ public abstract class DynamicExtensionsApplicationContextBase extends OsgiBundle
 
         if (version.compareTo(new VersionNumber("6.0")) >= 0) {
             // From Alfresco 6.x, we
-            this.bean(beanFactory, BeanNames.QUARTZ_TASK_SCHEDULER, Quartz2TaskScheduler.class, beanAutowireByType);
+            this.bean(beanFactory, BeanNames.QUARTZ_TASK_SCHEDULER, Quartz2TaskScheduler.class, beanAutowireByName);
         } else  {
             // Fallback to ScheduledTaskRegistrar on Alfresco 5.x
-            this.bean(beanFactory, BeanNames.QUARTZ_TASK_SCHEDULER, QuartzTaskScheduler.class, beanAutowireByType);
+            this.bean(beanFactory, BeanNames.QUARTZ_TASK_SCHEDULER, QuartzTaskScheduler.class, beanAutowireByName);
         }
         this.bean(beanFactory, BeanNames.SCHEDULED_TASK_REGISTRAR, ScheduledTaskRegistrar.class, beanAutowireByType);
     }
@@ -580,6 +580,13 @@ public abstract class DynamicExtensionsApplicationContextBase extends OsgiBundle
         @Override
         public void customize(BeanDefinitionBuilder builder) {
             builder.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_BY_TYPE);
+        }
+    };
+
+    public static BeanDefinitionBuilderCustomizer beanAutowireByName = new BeanDefinitionBuilderCustomizer() {
+        @Override
+        public void customize(BeanDefinitionBuilder builder) {
+            builder.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_BY_NAME);
         }
     };
 }

--- a/documentation/Extension_Point_Scheduled_Jobs.md
+++ b/documentation/Extension_Point_Scheduled_Jobs.md
@@ -1,5 +1,7 @@
 # Scheduled Jobs
 
+## Using Dynamic Extensions Annotations to Schedule Jobs
+
 To schedule the execution of some logic, annotate the class implementing the logic with `@ScheduledTask` 
 and implement the `com.github.dynamicextensionsalfresco.schedule.Task` interface. 
 
@@ -43,3 +45,17 @@ fallback to the value of the `cron` parameter as a default.
  
 > The `@ScheduledQuartzJob` annotation has been deprecated since Dynamic Extensions 2.0 and replace by the 
 > vendor neutral `@ScheduledTask` annotation. It still works on 2.0, but is scheduled for removing in later versions.
+
+## Implementation Notes
+
+Dynamic Extensions bundles should delegate the scheduling work to the DE Platform, rather than creating new - or 
+accessing existing Quartz schedulers directly.
+
+Should one need, for some reason, to access the scheduler directly, a simple `@Autowired` will not be sufficient, 
+due to the fact that there might be multiple beans of the same type.
+To get access to the Quartz Scheduler bean, please use `@Autowire` in combination with the `@Qualifier` notation:
+```java
+@Autowired
+@Qualifier("schedulerFactory")
+private Scheduler scheduler;
+``` 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -70,10 +70,18 @@ configure(subprojects.findAll { it.name.startsWith("alfresco-") }) {
             automaticTags = false
         }
     }
-    
+
+    def issue_297_config = project.getName().contains("-6")
+            ? "github-issue-297-6.x-application-context.xml"
+            : "github-issue-297-5.x-application-context.xml"
+
     createDockerFile {
         // Workaround for https://issues.alfresco.com/jira/browse/MNT-20007
         runCommand("sed -i 's|<secure>true</secure>|<secure>false</secure>|g' /usr/local/tomcat/conf/web.xml")
+        smartCopy(
+                "${project.getParent().getProjectDir()}/src/test/resources/${issue_297_config}",
+                "/usr/local/tomcat/shared/classes/alfresco/extension/${issue_297_config}"
+        )
     }
 
     dockerCompose {

--- a/integration-tests/src/test/resources/github-issue-297-5.x-application-context.xml
+++ b/integration-tests/src/test/resources/github-issue-297-5.x-application-context.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans profile="multipleQuartzSchedulers"
+        xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean id="customQuartzScheduler" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
+        <property name="triggers"><list/></property>
+    </bean>
+</beans>

--- a/integration-tests/src/test/resources/github-issue-297-6.x-application-context.xml
+++ b/integration-tests/src/test/resources/github-issue-297-6.x-application-context.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans profile="multipleQuartzSchedulers"
+        xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean id="customQuartzScheduler" class="org.alfresco.schedule.AlfrescoSchedulerAccessorBean">
+        <property name="scheduler" ref="schedulerFactory"/>
+        <property name="triggers"><list/></property>
+        <property name="enabled" value="true" />
+    </bean>
+</beans>


### PR DESCRIPTION
- Registered Quartz Scheduler by Name instead of by Type
- Added `@Qualifier` annotation in the `QuartzTaskScheduler`s

## Description
When we register the `QuartzTaskScheduler` and `Quartz2TaskScheduler`, we specify what type of `@Autowire` is supported for those beans. Until now, this was by type, but since we have collisions of multiple beans with the same type, we must register those `QuartzTaskScheduler` and `Quartz2TaskScheduler` beans by name in order to be able to `@Autowire` it by `@Qualifier`.
The next step was to ensure that the `Scheduler`'s referenced in the `QuartzTaskScheduler` and `Quartz2TaskScheduler` have `@Qualifier` annotation to avoid the same (type-based) bean collisions.

## Related Issue
#297 

## Motivation and Context
Unless this issue is resolved, components that create Quartz Scheduler Factory outside of Dynamic Extensions will cause the bootstrap of DE Schedulers to fail, causing scheduling failures across all DE modules that are deployed.

## How Has This Been Tested?
1. Setup
1.1. Dynamic Extensions 2.0.3 or older
1.2. https://github.com/xenit-eu/alfresco-hotfix-ALF-22094 any version
2. Instructions
2.1. Startup Alfresco
2.2. Look for the bootstrapping of Dynamic Extensions modules

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
  - Modules that are **not** DE bundles, and use Quartzs' default scheduler **must** now use the `@Qualifier("schedulerFactory")` annotation, since it is now registered by name instead of by type.
  - Modules that **are** DE bundles, should not directly use the scheduler, but rather delegate the interaction to the DE platform

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the changelog.
