### PR TITLE
Fixed issue where Alfresco will not start when Dynamic-extensions and…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Version template:
 ## [2.0.4] - UNRELEASED
 ### Fixed
 * [#297](https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/297) Multiple bean candidates for a Quartz' `SchedulerFactoryBean`
+* [#201](https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/201) Fixed issue where Alfresco would not start when Dynamic-extensions and Records Management are installed at the same time
 
 
 ## [2.0.3] - 2020-03-12


### PR DESCRIPTION
… Records management are installed

Disabled publishing of context refresh events and context closed events.

## Description
Added EventHandlingXmlWebApplicationContext to OsgiContainerModuleComponent which overrides the publishEvent method so publishing is disabled for ApplicationEvents of type ContextRefreshedEvent and ContextClosedEvent.

## Related Issue
https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/201

## Motivation and Context
Alfresco does not start when Dynamic-extensions and Records management are installed at the same time.

## How Has This Been Tested?
Manually by starting the Alfresco with both Dynamic-extensions and Records management.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the changelog.
