### PR TITLE
DEVEM-462 Missing Parameter results in 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Version template:
 ## [2.0.5] - UNRELEASED
 ### Fixed
 * [#306](https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/306) Alfresco 6.2.1 issues due to cglib imports in control-panel bundle
+* [#308](https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/308) Calling webscript without required @RequestParam causes 500 error response
 
 ## [2.0.4] - 2020-05-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Version template:
 ## [2.0.5] - UNRELEASED
 ### Fixed
 * [#306](https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/306) Alfresco 6.2.1 issues due to cglib imports in control-panel bundle
-* [#308](https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/308) Calling webscript without required @RequestParam causes 500 error response
+* [#308](https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/308) Calling webscript without required `@RequestParam` causes 500 error response
 
 ## [2.0.4] - 2020-05-27
 ### Fixed
@@ -113,5 +113,4 @@ Registering a component implementing multiple Activiti listener Interfaces throw
 ### Fixed
 * [#143](https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/143) WebScriptUtil.extractHttpServletResponse() not working.
 * [#151](https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/151) @ResponseBody with void return type causes NullpointerException
-
 

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestParamHandler.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestParamHandler.java
@@ -53,4 +53,20 @@ public class RequestParamHandler {
 	@Uri("/handleNodeRef")
 	public void handleNodeRef(@RequestParam final NodeRef nodeRef) {
 	}
+
+	@Uri("/handleMissingRequiredParameterDefault")
+	public void handleMissingRequiredParameterDefault(@RequestParam final String expectedCode) {
+	}
+
+	@Uri("/handleMissingRequiredParameter123")
+	public void handleMissingRequiredParameter123(@RequestParam(missingParameterHttpStatusCode = 123) final String expectedCode) {
+	}
+
+	@Uri("/handleMissingParameterDefault")
+	public void handleMissingParameterDefault(@RequestParam(required = false) final String expectedCode) {
+	}
+
+	@Uri("/handleMissingParameter123")
+	public void handleMissingParameter123(@RequestParam(missingParameterHttpStatusCode = 123, required = false) final String expectedCode) {
+	}
 }

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestParamHandler.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestParamHandler.java
@@ -58,15 +58,15 @@ public class RequestParamHandler {
 	public void handleMissingRequiredParameterDefault(@RequestParam final String expectedCode) {
 	}
 
-	@Uri("/handleMissingRequiredParameter123")
-	public void handleMissingRequiredParameter123(@RequestParam(missingParameterHttpStatusCode = 123) final String expectedCode) {
+	@Uri("/handleMissingRequiredParameter422")
+	public void handleMissingRequiredParameter422(@RequestParam(missingParameterHttpStatusCode = 422) final String expectedCode) {
 	}
 
-	@Uri("/handleNonRequiredMissingParameter")
-	public void handleNonRequiredMissingParameter(@RequestParam(required = false) final String expectedCode) {
+	@Uri("/handleOptionalMissingParameter")
+	public void handleOptionalMissingParameter(@RequestParam(required = false) final String expectedCode) {
 	}
 
-	@Uri("/handleNonRequiredMissingParameter123")
-	public void handleNonRequiredMissingParameter123(@RequestParam(missingParameterHttpStatusCode = 123, required = false) final String expectedCode) {
+	@Uri("/handleOptionalMissingParameter422")
+	public void handleOptionalMissingParameter422(@RequestParam(missingParameterHttpStatusCode = 422, required = false) final String expectedCode) {
 	}
 }

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestParamHandler.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestParamHandler.java
@@ -62,11 +62,11 @@ public class RequestParamHandler {
 	public void handleMissingRequiredParameter123(@RequestParam(missingParameterHttpStatusCode = 123) final String expectedCode) {
 	}
 
-	@Uri("/handleMissingParameterDefault")
-	public void handleMissingParameterDefault(@RequestParam(required = false) final String expectedCode) {
+	@Uri("/handleNonRequiredMissingParameter")
+	public void handleNonRequiredMissingParameter(@RequestParam(required = false) final String expectedCode) {
 	}
 
-	@Uri("/handleMissingParameter123")
-	public void handleMissingParameter123(@RequestParam(missingParameterHttpStatusCode = 123, required = false) final String expectedCode) {
+	@Uri("/handleNonRequiredMissingParameter123")
+	public void handleNonRequiredMissingParameter123(@RequestParam(missingParameterHttpStatusCode = 123, required = false) final String expectedCode) {
 	}
 }

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestParamTest.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestParamTest.java
@@ -115,27 +115,27 @@ public class RequestParamTest extends AbstractWebScriptAnnotationsTest {
 	@Test
 	public void testHandleMissingRequiredParameterWithCustomHttpStatus() {
 		try {
-			handleGet("/handleMissingRequiredParameter123", new MockWebScriptRequest());
-			verify(handler).handleMissingRequiredParameter123(eq(null));
+			handleGet("/handleMissingRequiredParameter422", new MockWebScriptRequest());
+			verify(handler).handleMissingRequiredParameter422(eq(null));
 			Assert.fail("Must throw an WebScriptException!");
 		} catch (WebScriptException ex) {
-			assertEquals(ex.getStatus(), 123);
+			assertEquals(ex.getStatus(), 422);
 		} catch (Exception ex) {
 			Assert.fail("Must throw an WebScriptException!");
 		}
 	}
 
 	@Test
-	public void testHandleNonRequiredMissingParameter() {
-		handleGet("/handleNonRequiredMissingParameter", new MockWebScriptRequest());
-		verify(handler).handleNonRequiredMissingParameter(eq(null));
+	public void testHandleOptionalMissingParameter() {
+		handleGet("/handleOptionalMissingParameter", new MockWebScriptRequest());
+		verify(handler).handleOptionalMissingParameter(eq(null));
 		assertTrue(true); // no exceptions thrown = GOOD!
 	}
 
 	@Test
-	public void testHandleNonRequiredMissingParameterWithCustomHttpStatus() {
-		handleGet("/handleNonRequiredMissingParameter123", new MockWebScriptRequest());
-		verify(handler).handleNonRequiredMissingParameter123(eq(null));
+	public void testHandleOptionalMissingParameterWithCustomHttpStatus() {
+		handleGet("/handleOptionalMissingParameter422", new MockWebScriptRequest());
+		verify(handler).handleOptionalMissingParameter422(eq(null));
 		assertTrue(true); // no exceptions thrown = GOOD!
 	}
 }

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestParamTest.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestParamTest.java
@@ -106,7 +106,7 @@ public class RequestParamTest extends AbstractWebScriptAnnotationsTest {
 			verify(handler).handleMissingRequiredParameterDefault(eq(null));
 			Assert.fail("Must throw an WebScriptException!");
 		} catch (WebScriptException ex) {
-			assertEquals(422, ex.getStatus());
+			assertEquals(400, ex.getStatus());
 		} catch (Exception ex) {
 			Assert.fail("Must throw an WebScriptException!");
 		}

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestParamTest.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestParamTest.java
@@ -126,16 +126,16 @@ public class RequestParamTest extends AbstractWebScriptAnnotationsTest {
 	}
 
 	@Test
-	public void testHandleMissingParameterDefault() {
-		handleGet("/handleMissingParameterDefault", new MockWebScriptRequest());
-		verify(handler).handleMissingParameterDefault(eq(null));
+	public void testHandleNonRequiredMissingParameter() {
+		handleGet("/handleNonRequiredMissingParameter", new MockWebScriptRequest());
+		verify(handler).handleNonRequiredMissingParameter(eq(null));
 		assertTrue(true); // no exceptions thrown = GOOD!
 	}
 
 	@Test
-	public void testHandleMissingParameterWithCustomHttpStatus() {
-		handleGet("/handleMissingParameter123", new MockWebScriptRequest());
-		verify(handler).handleMissingParameter123(eq(null));
+	public void testHandleNonRequiredMissingParameterWithCustomHttpStatus() {
+		handleGet("/handleNonRequiredMissingParameter123", new MockWebScriptRequest());
+		verify(handler).handleNonRequiredMissingParameter123(eq(null));
 		assertTrue(true); // no exceptions thrown = GOOD!
 	}
 }

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestParamTest.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/RequestParamTest.java
@@ -1,14 +1,21 @@
 package com.github.dynamicextensionsalfresco.webscripts;
 
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.github.dynamicextensionsalfresco.webscripts.annotations.RequestParam;
 
 import org.alfresco.model.ContentModel;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.namespace.NamespacePrefixResolver;
 import org.alfresco.service.namespace.NamespaceService;
+import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.extensions.webscripts.WebScriptException;
 
 /**
  * Integration test for {@link RequestParam} handling.
@@ -90,5 +97,45 @@ public class RequestParamTest extends AbstractWebScriptAnnotationsTest {
 		handleGet("/handleNodeRef", new MockWebScriptRequest().param("nodeRef",
 				"workspace://SpacesStore/c269c803-4fd6-4aad-9114-3a42ff263fdc"));
 		verify(handler).handleNodeRef(new NodeRef("workspace://SpacesStore/c269c803-4fd6-4aad-9114-3a42ff263fdc"));
+	}
+
+	@Test
+	public void testHandleMissingRequiredParameterDefault() {
+		try {
+			handleGet("/handleMissingRequiredParameterDefault", new MockWebScriptRequest());
+			verify(handler).handleMissingRequiredParameterDefault(eq(null));
+			Assert.fail("Must throw an WebScriptException!");
+		} catch (WebScriptException ex) {
+			assertEquals(422, ex.getStatus());
+		} catch (Exception ex) {
+			Assert.fail("Must throw an WebScriptException!");
+		}
+	}
+
+	@Test
+	public void testHandleMissingRequiredParameterWithCustomHttpStatus() {
+		try {
+			handleGet("/handleMissingRequiredParameter123", new MockWebScriptRequest());
+			verify(handler).handleMissingRequiredParameter123(eq(null));
+			Assert.fail("Must throw an WebScriptException!");
+		} catch (WebScriptException ex) {
+			assertEquals(ex.getStatus(), 123);
+		} catch (Exception ex) {
+			Assert.fail("Must throw an WebScriptException!");
+		}
+	}
+
+	@Test
+	public void testHandleMissingParameterDefault() {
+		handleGet("/handleMissingParameterDefault", new MockWebScriptRequest());
+		verify(handler).handleMissingParameterDefault(eq(null));
+		assertTrue(true); // no exceptions thrown = GOOD!
+	}
+
+	@Test
+	public void testHandleMissingParameterWithCustomHttpStatus() {
+		handleGet("/handleMissingParameter123", new MockWebScriptRequest());
+		verify(handler).handleMissingParameter123(eq(null));
+		assertTrue(true); // no exceptions thrown = GOOD!
 	}
 }

--- a/annotations/src/main/java/com/github/dynamicextensionsalfresco/webscripts/annotations/RequestParam.java
+++ b/annotations/src/main/java/com/github/dynamicextensionsalfresco/webscripts/annotations/RequestParam.java
@@ -31,4 +31,8 @@ public @interface RequestParam {
 	 */
 	String delimiter() default "";
 
+	/**
+	 * Specifies the status code to be returned when a required parameter is missing
+	 */
+	int missingParameterHttpStatusCode() default 422;
 }

--- a/annotations/src/main/java/com/github/dynamicextensionsalfresco/webscripts/annotations/RequestParam.java
+++ b/annotations/src/main/java/com/github/dynamicextensionsalfresco/webscripts/annotations/RequestParam.java
@@ -34,5 +34,5 @@ public @interface RequestParam {
 	/**
 	 * Specifies the status code to be returned when a required parameter is missing
 	 */
-	int missingParameterHttpStatusCode() default 422;
+	int missingParameterHttpStatusCode() default 400;
 }


### PR DESCRIPTION
Replaced `IllegalStateException` with `WebScriptException` that accepts the configurable http status code from the request parameter annotation to return in case of missing required request parameter

## Description
When a webscript argument annotated with `@RequestParam` is missing from an HTTP request, an IllegalStateException is thrown, causing Alfresco to return a 500 error response.

## Related Issue
https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/308

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested with `curl -v -X GET "http://username:password@host:port/alfresco/s/dynamic-extensions/examples/hello"` from https://github.com/xenit-eu/example-dynamic-extension/blob/master/gradle-with-plugin/src/main/java/eu/xenit/de/example/HelloWebScript.java#L35
Also added unit tests for the following scenarios:
- [X] Required Param = true; Http Status Code Defaults to 400; Exception is thrown and matches status code 400
- [X] Required Param = true; Custom Http Status Code 123; Exception is thrown and matches status code 123
- [X] Required Param = false; Http Status Code Defaults to 400; No Exception is thrown
- [X] Required Param = false; Custom Http Status Code 123; No Exception is thrown

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the changelog.
