### PR TITLE
ALFHOST-837 improve ScheduledTask documentation page

### DIFF
--- a/documentation/Extension_Point_Scheduled_Jobs.md
+++ b/documentation/Extension_Point_Scheduled_Jobs.md
@@ -42,9 +42,20 @@ public class ScheduledExampleTask implements Task {
 
 If the property `eu.xenit.example.cron` is available it's value is used as cron expression. Otherwise DE will 
 fallback to the value of the `cron` parameter as a default. 
- 
-> The `@ScheduledQuartzJob` annotation has been deprecated since Dynamic Extensions 2.0 and replace by the 
-> vendor neutral `@ScheduledTask` annotation. It still works on 2.0, but is scheduled for removing in later versions.
+
+If in a clustered environment the job may only run on one node at a time, set the property `cluster = true` on the `ScheduledTask` annotation.
+
+```java
+...
+@Component
+@ScheduledTask(name = "example", cron = "0/15 * * * * ?", cluster = true)
+public class ScheduledExampleTask implements Task {
+...
+```
+
+## Deprication Notice: `ScheduledQuartzJob` 
+The `@ScheduledQuartzJob` annotation has been deprecated since Dynamic Extensions 2.0 and replace by the 
+vendor neutral `@ScheduledTask` annotation. It still works on 2.0, but is scheduled for removing in later versions.
 
 ## Implementation Notes
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes add section on the `cluster` property, and improve visibility of the `ScheduledQuartzJob` deprication, on the `ScheduledTask` documentation page

## Related Issue
https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/314

## Motivation and Context
Change would prevent unnecessary implementation of native alfresco job-locking mechanisms

## How Has This Been Tested?
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the changelog.
