### PR TITLE
#319 Update @ExceptionHandler documentation

### DIFF
--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ExceptionHandlerAbstractClass.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ExceptionHandlerAbstractClass.java
@@ -1,0 +1,16 @@
+package com.github.dynamicextensionsalfresco.webscripts;
+
+import static org.junit.Assert.assertNotNull;
+
+import com.github.dynamicextensionsalfresco.webscripts.annotations.ExceptionHandler;
+
+public abstract class ExceptionHandlerAbstractClass extends AbstractWebScriptAnnotationsTest {
+
+    IndexOutOfBoundsException indexOutOfBoundsException;
+
+    @ExceptionHandler(IndexOutOfBoundsException.class)
+    protected void handleIndexOutOfBoundsException(final IndexOutOfBoundsException e) {
+        indexOutOfBoundsException = e;
+    }
+
+}

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ExceptionHandlerAbstractClass.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ExceptionHandlerAbstractClass.java
@@ -1,10 +1,8 @@
 package com.github.dynamicextensionsalfresco.webscripts;
 
-import static org.junit.Assert.assertNotNull;
-
 import com.github.dynamicextensionsalfresco.webscripts.annotations.ExceptionHandler;
 
-public abstract class ExceptionHandlerAbstractClass extends AbstractWebScriptAnnotationsTest {
+public abstract class ExceptionHandlerAbstractClass {
 
     IndexOutOfBoundsException indexOutOfBoundsException;
 

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ExceptionHandlerExample.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ExceptionHandlerExample.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Spied
-public class ExceptionHandlerExample {
+public class ExceptionHandlerExample extends ExceptionHandlerAbstractClass implements ExceptionHandlerInterface {
 
 	IllegalArgumentException illegalArgumentException;
 
@@ -26,6 +26,16 @@ public class ExceptionHandlerExample {
 	@Uri("/throwIllegalStateException")
 	public void throwIllegalStateException() {
 		throw new IllegalStateException();
+	}
+
+	@Uri("/throwUnsupportedOperationException")
+	public void throwUnsupportedOperationException() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Uri("/throwIndexOutOfBoundsException")
+	public void throwIndexOutOfBoundsException() {
+		throw new IndexOutOfBoundsException();
 	}
 
 	/* Utility operations */

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ExceptionHandlerInterface.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ExceptionHandlerInterface.java
@@ -1,0 +1,14 @@
+package com.github.dynamicextensionsalfresco.webscripts;
+
+import static org.junit.Assert.assertNotNull;
+
+import com.github.dynamicextensionsalfresco.webscripts.annotations.ExceptionHandler;
+
+public interface ExceptionHandlerInterface {
+
+    @ExceptionHandler(UnsupportedOperationException.class)
+    default void handleUnsupportedOperationException(final UnsupportedOperationException ignore) {
+        assertNotNull(ignore);
+    }
+
+}

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ExceptionHandlerTest.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ExceptionHandlerTest.java
@@ -2,12 +2,14 @@ package com.github.dynamicextensionsalfresco.webscripts;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 
-import org.junit.Ignore;
+import java.util.Objects;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.SpringVersion;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
@@ -34,8 +36,10 @@ public class ExceptionHandlerTest extends AbstractWebScriptAnnotationsTest {
     }
 
     @Test
-    @Ignore // @ExceptionHandler annotated default method in interfaces do not work for Alfresco <= 5.
     public void testHandleExceptionByDefaultInterfaceMethod() {
+        assumeTrue("Annotated default methods in interfaces is only supported starting from Alfresco 6",
+                getSpringMajorVersion() >= 5);
+
         handleGet("/throwUnsupportedOperationException");
         assertNull(handler.illegalArgumentException);
         assertNotNull(handler.throwable);
@@ -49,5 +53,9 @@ public class ExceptionHandlerTest extends AbstractWebScriptAnnotationsTest {
         assertNotNull(handler.throwable);
         assertNotNull(handler.indexOutOfBoundsException);
         verify(handler).handleIndexOutOfBoundsException(any(IndexOutOfBoundsException.class));
+    }
+
+    private static int getSpringMajorVersion() {
+        return Integer.parseInt(Objects.requireNonNull(SpringVersion.getVersion()).substring(0, 1));
     }
 }

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ExceptionHandlerTest.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ExceptionHandlerTest.java
@@ -1,6 +1,9 @@
 package com.github.dynamicextensionsalfresco.webscripts;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,22 +13,39 @@ import org.springframework.test.annotation.DirtiesContext.ClassMode;
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class ExceptionHandlerTest extends AbstractWebScriptAnnotationsTest {
 
-	@Autowired
-	private ExceptionHandlerExample handler;
+    @Autowired
+    private ExceptionHandlerExample handler;
 
-	@Test
-	public void testHandleExceptionOfOneType() {
-		handleGet("/throwIllegalArgumentException");
-		assertNotNull(handler.illegalArgumentException);
-		assertNotNull(handler.throwable);
-		assertNull(handler.illegalStateException);
-	}
+    @Test
+    public void testHandleExceptionOfOneType() {
+        handleGet("/throwIllegalArgumentException");
+        assertNotNull(handler.illegalArgumentException);
+        assertNotNull(handler.throwable);
+        assertNull(handler.illegalStateException);
+    }
 
-	@Test
-	public void testHandleExceptionOfAnotherType() {
-		handleGet("/throwIllegalStateException");
-		assertNull(handler.illegalArgumentException);
-		assertNotNull(handler.throwable);
-		assertNotNull(handler.illegalStateException);
-	}
+    @Test
+    public void testHandleExceptionOfAnotherType() {
+        handleGet("/throwIllegalStateException");
+        assertNull(handler.illegalArgumentException);
+        assertNotNull(handler.throwable);
+        assertNotNull(handler.illegalStateException);
+    }
+
+    @Test
+    public void testHandleExceptionByDefaultInterfaceMethod() {
+        handleGet("/throwUnsupportedOperationException");
+        assertNull(handler.illegalArgumentException);
+        assertNotNull(handler.throwable);
+        assertNull(handler.illegalStateException);
+        verify(handler).handleUnsupportedOperationException(any(UnsupportedOperationException.class));
+    }
+
+    @Test
+    public void testHandleExceptionByMethodInParent() {
+        handleGet("/throwIndexOutOfBoundsException");
+        assertNotNull(handler.throwable);
+        assertNotNull(handler.indexOutOfBoundsException);
+        verify(handler).handleIndexOutOfBoundsException(any(IndexOutOfBoundsException.class));
+    }
 }

--- a/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ExceptionHandlerTest.java
+++ b/annotations-runtime/src/test/java/com/github/dynamicextensionsalfresco/webscripts/ExceptionHandlerTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
@@ -33,6 +34,7 @@ public class ExceptionHandlerTest extends AbstractWebScriptAnnotationsTest {
     }
 
     @Test
+    @Ignore // @ExceptionHandler annotated default method in interfaces do not work for Alfresco <= 5.
     public void testHandleExceptionByDefaultInterfaceMethod() {
         handleGet("/throwUnsupportedOperationException");
         assertNull(handler.illegalArgumentException);

--- a/documentation/Extension_Point_WebScripts.md
+++ b/documentation/Extension_Point_WebScripts.md
@@ -200,8 +200,9 @@ protected void handleIllegalArgument(IllegalArgumentException exception, WebScri
 ```
 This handler method must be defined in the same `@WebScript` annotated class that will throw the Exceptions to be handled.
 
-It is also possible to separate out exception handler methods into their own class, using an interface with default methods.
-The interface can then be implemented by any `@WebScript` class that requires it:
+**As of Alfresco 6**, it is also possible to separate out exception handler methods into their own class, 
+using an interface with default methods. The interface can then be implemented by any `@WebScript` class that 
+requires it:
 ```java
 public interface ExceptionHandlers {
     @ExceptionHandler(IllegalArgumentException.class)

--- a/integration-tests/src/test/java/eu/xenit/dynamicextensionsalfresco/ExceptionHandlersTest.java
+++ b/integration-tests/src/test/java/eu/xenit/dynamicextensionsalfresco/ExceptionHandlersTest.java
@@ -1,0 +1,27 @@
+package eu.xenit.dynamicextensionsalfresco;
+
+import static io.restassured.RestAssured.given;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExceptionHandlersTest extends RestAssuredTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(BehaviourTest.class);
+
+    @Test
+    public void testExceptionHandler_iAmATeapot() {
+        logger.info("Test scenario: check that the 'OnCreateNodePolicy' behaviour is triggered when creating an "
+                + "applicable node");
+
+        given()
+                .log().ifValidationFails()
+                .when()
+                .get("s/dynamic-extensions/testing/exceptions/IAmATeapot")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(418);
+    }
+
+}

--- a/integration-tests/src/test/java/eu/xenit/dynamicextensionsalfresco/ExceptionHandlersTest.java
+++ b/integration-tests/src/test/java/eu/xenit/dynamicextensionsalfresco/ExceptionHandlersTest.java
@@ -1,8 +1,8 @@
 package eu.xenit.dynamicextensionsalfresco;
 
 import static io.restassured.RestAssured.given;
+import static org.junit.Assume.assumeTrue;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,8 +12,10 @@ public class ExceptionHandlersTest extends RestAssuredTest {
     private static final Logger logger = LoggerFactory.getLogger(BehaviourTest.class);
 
     @Test
-    @Ignore // @ExceptionHandler annotated default method in interfaces do not work for Alfresco <= 5.
     public void testExceptionHandler_iAmATeapot() {
+        assumeTrue("Annotated default methods in interfaces is only supported starting from Alfresco 6",
+                getAlfrescoMajorVersion() >= 6);
+
         logger.info("Test scenario: check that the 'OnCreateNodePolicy' behaviour is triggered when creating an "
                 + "applicable node");
 

--- a/integration-tests/src/test/java/eu/xenit/dynamicextensionsalfresco/ExceptionHandlersTest.java
+++ b/integration-tests/src/test/java/eu/xenit/dynamicextensionsalfresco/ExceptionHandlersTest.java
@@ -2,6 +2,7 @@ package eu.xenit.dynamicextensionsalfresco;
 
 import static io.restassured.RestAssured.given;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,6 +12,7 @@ public class ExceptionHandlersTest extends RestAssuredTest {
     private static final Logger logger = LoggerFactory.getLogger(BehaviourTest.class);
 
     @Test
+    @Ignore // @ExceptionHandler annotated default method in interfaces do not work for Alfresco <= 5.
     public void testExceptionHandler_iAmATeapot() {
         logger.info("Test scenario: check that the 'OnCreateNodePolicy' behaviour is triggered when creating an "
                 + "applicable node");

--- a/integration-tests/src/test/java/eu/xenit/dynamicextensionsalfresco/RestAssuredTest.java
+++ b/integration-tests/src/test/java/eu/xenit/dynamicextensionsalfresco/RestAssuredTest.java
@@ -1,5 +1,6 @@
 package eu.xenit.dynamicextensionsalfresco;
 
+import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.preemptive;
 
 import io.restassured.RestAssured;
@@ -28,6 +29,20 @@ public abstract class RestAssuredTest {
         logger.info("REST-Assured initialized with following URI: {}:{}{}", baseURI, port, basePath);
 
         RestAssured.authentication = preemptive().basic(ALFRESCO_USERNAME, ALFRESCO_PASSWORD);
+    }
+
+    protected int getAlfrescoMajorVersion() {
+        return given()
+                .log().ifValidationFails()
+                .when()
+                .get("s/dynamic-extensions/testing/alfresco-version")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .extract()
+                .body()
+                .jsonPath()
+                .getInt("major");
     }
 
 }

--- a/integration-tests/test-bundle/build.gradle
+++ b/integration-tests/test-bundle/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     alfrescoProvided('org.springframework:spring-beans') { transitive = false }
     alfrescoProvided('org.springframework:spring-context') { transitive = false }
     alfrescoProvided('org.springframework:spring-web') { transitive = false }
+    alfrescoProvided("org.springframework.extensions.surf:spring-webscripts:5.0.d") { transitive = false }
 
     alfrescoProvided('org.slf4j:slf4j-api')
 }

--- a/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/AlfrescoVersionWebScript.java
+++ b/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/AlfrescoVersionWebScript.java
@@ -1,0 +1,60 @@
+package eu.xenit.de.testing;
+
+import static eu.xenit.de.testing.Constants.TEST_WEBSCRIPTS_BASE_URI;
+import static eu.xenit.de.testing.Constants.TEST_WEBSCRIPTS_FAMILY;
+
+import com.github.dynamicextensionsalfresco.webscripts.annotations.Uri;
+import com.github.dynamicextensionsalfresco.webscripts.annotations.WebScript;
+import org.alfresco.service.descriptor.Descriptor;
+import org.alfresco.service.descriptor.DescriptorService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Component
+@WebScript(families = TEST_WEBSCRIPTS_FAMILY, baseUri = TEST_WEBSCRIPTS_BASE_URI)
+@SuppressWarnings("unused")
+public class AlfrescoVersionWebScript {
+
+    @Autowired
+    private DescriptorService descriptorService;
+
+    @Uri("/alfresco-version")
+    @ResponseBody
+    public AlfrescoVersion getAlfrescoVersion() {
+        return new AlfrescoVersion(descriptorService.getCurrentRepositoryDescriptor());
+    }
+
+    private static class AlfrescoVersion {
+
+        private final String version;
+        private final int major;
+        private final int minor;
+        private final int revision;
+
+        AlfrescoVersion(Descriptor descriptor) {
+            this.version = descriptor.getVersion();
+            this.major = Integer.parseInt(descriptor.getVersionMajor());
+            this.minor = Integer.parseInt(descriptor.getVersionMinor());
+            this.revision = Integer.parseInt(descriptor.getVersionRevision());
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public int getMajor() {
+            return major;
+        }
+
+        public int getMinor() {
+            return minor;
+        }
+
+        public int getRevision() {
+            return revision;
+        }
+    }
+
+
+}

--- a/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/exceptionhandlers/ExceptionHandlers.java
+++ b/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/exceptionhandlers/ExceptionHandlers.java
@@ -1,0 +1,14 @@
+package eu.xenit.de.testing.exceptionhandlers;
+
+import com.github.dynamicextensionsalfresco.webscripts.annotations.ExceptionHandler;
+import org.springframework.extensions.webscripts.WebScriptResponse;
+import org.springframework.http.HttpStatus;
+
+public interface ExceptionHandlers {
+
+    @ExceptionHandler(IAmATeapotException.class)
+    default void handle(IAmATeapotException exception, WebScriptResponse response) {
+        response.setStatus(HttpStatus.I_AM_A_TEAPOT.value());
+    }
+
+}

--- a/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/exceptionhandlers/ExceptionThrowingWebScripts.java
+++ b/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/exceptionhandlers/ExceptionThrowingWebScripts.java
@@ -1,0 +1,20 @@
+package eu.xenit.de.testing.exceptionhandlers;
+
+import static eu.xenit.de.testing.Constants.TEST_WEBSCRIPTS_BASE_URI;
+import static eu.xenit.de.testing.Constants.TEST_WEBSCRIPTS_FAMILY;
+
+import com.github.dynamicextensionsalfresco.webscripts.annotations.Uri;
+import com.github.dynamicextensionsalfresco.webscripts.annotations.WebScript;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Component
+@WebScript(families = TEST_WEBSCRIPTS_FAMILY, baseUri = TEST_WEBSCRIPTS_BASE_URI + "/exceptions")
+public class ExceptionThrowingWebScripts implements ExceptionHandlers {
+
+    @ResponseBody
+    @Uri(value = "/IAmATeapot")
+    public void throwIAmATeapotException() {
+        throw new IAmATeapotException();
+    }
+}

--- a/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/exceptionhandlers/IAmATeapotException.java
+++ b/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/exceptionhandlers/IAmATeapotException.java
@@ -1,0 +1,5 @@
+package eu.xenit.de.testing.exceptionhandlers;
+
+public class IAmATeapotException extends RuntimeException {
+
+}


### PR DESCRIPTION
Fixes #319 

As discovered in #319 , using the `@ExceptionHandler` on `default` interface methods doesn't work for Alfresco <= 5. 
This PR updates the documentation with an indication this optimization can only be used in Alfresco >= 6. 

I also added some additional (integration) tests for the `@ExcpetionHandler` behavior, which are ignored for now. If at some point in the future we drop Alfresco 5 support, we can reintroduce them. 
