### PR TITLE
XENOPS-891 update enterprise integration test wars & baseimages

### DIFF
--- a/integration-tests/alfresco-enterprise-52/overload.gradle
+++ b/integration-tests/alfresco-enterprise-52/overload.gradle
@@ -1,6 +1,6 @@
 ext {
-    alfrescoBaseWar = 'org.alfresco:alfresco-enterprise:5.2.7.3@war'
-    alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:5.2.7.3'
+    alfrescoBaseWar = 'org.alfresco:alfresco-enterprise:5.2.7.12@war'
+    alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:5.2.7.12'
     
     postgresImage = 'postgres:10.1'
 }

--- a/integration-tests/alfresco-enterprise-52/overload.gradle
+++ b/integration-tests/alfresco-enterprise-52/overload.gradle
@@ -1,5 +1,5 @@
 ext {
-    alfrescoBaseWar = 'org.alfresco:alfresco-enterprise:5.2.7.12@war'
+    alfrescoBaseWar = 'org.alfresco:alfresco-platform-enterprise:5.2.7.12@war'
     alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:5.2.7.12'
     
     postgresImage = 'postgres:10.1'

--- a/integration-tests/alfresco-enterprise-62/overload.gradle
+++ b/integration-tests/alfresco-enterprise-62/overload.gradle
@@ -1,5 +1,6 @@
 ext {
-    alfrescoBaseWar = 'org.alfresco:content-services:6.2.2.19@war'
+    alfrescoBaseWarBom = 'org.alfresco:acs-packaging:6.2.2.19'
+    alfrescoBaseWar = 'org.alfresco:content-services@war'
     alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.2.2.19'
 
     postgresImage = 'postgres:10.1'

--- a/integration-tests/alfresco-enterprise-62/overload.gradle
+++ b/integration-tests/alfresco-enterprise-62/overload.gradle
@@ -1,6 +1,6 @@
 ext {
-    alfrescoBaseWar = 'org.alfresco:content-services:6.2.2@war'
-    alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.2.2'
+    alfrescoBaseWar = 'org.alfresco:content-services:6.2.2.19@war'
+    alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.2.2.19'
 
     postgresImage = 'postgres:10.1'
 }

--- a/integration-tests/alfresco-enterprise-70/overload.gradle
+++ b/integration-tests/alfresco-enterprise-70/overload.gradle
@@ -1,8 +1,8 @@
 ext {
-    alfrescoBaseWarBom = 'org.alfresco:acs-packaging:7.0.0'
+    alfrescoBaseWarBom = 'org.alfresco:acs-packaging:7.0.1.3'
     alfrescoBaseWar = 'org.alfresco:content-services@war'
 
-    alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:7.0.0'
+    alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:7.0.1.3'
 
     postgresImage = 'postgres:13.1'
 }


### PR DESCRIPTION
Sliding image tag on 6.2.2 changed the used image to the latest hotfix, causing a check on dockerimage<>basewar to fail.

This change pins the versions for the functional hotfixed images (5.2, 6.2 & 7.0).

6.1 was already pinned to the previous version. It is not updated in this change due to issues with the latest hotfix war (see ticket).

Support for the xenit 50, 51 and 60 images was dropped. They will keep using the latest released image.

Community images did not receive patches and will not be changed.