### PR TITLE
DEVEM 499 Fix @ActionMethod usage on Alfresco 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Version template:
 # Dynamic Extensions For Alfresco Changelog
 
 ## [2.1.2] - UNRELEASED
+### Fixed
+* [#338](https://github.com/xenit-eu/dynamic-extensions-for-alfresco/issues/338) DEVEM-499 Fix @ActionMethod usage on Alfresco 7.0
 
 ## [2.1.1] - 2021-09-08
 ### Fixed

--- a/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/actions/AnnotationBasedActionRegistrar.java
+++ b/annotations-runtime/src/main/java/com/github/dynamicextensionsalfresco/actions/AnnotationBasedActionRegistrar.java
@@ -22,7 +22,6 @@ import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.namespace.QName;
-import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
@@ -31,6 +30,7 @@ import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.ReflectionUtils.MethodCallback;
+import org.springframework.util.StringUtils;
 
 /**
  * Manages annotation-based Actions in a {@link BeanFactory}.
@@ -229,7 +229,8 @@ public class AnnotationBasedActionRegistrar extends AbstractAnnotationBasedRegis
 					}
 					final boolean mandatory = actionParameter.mandatory();
 					final String displayLabel = actionParameter.displayLabel();
-					final String constraintName = StringUtils.stripToNull(actionParameter.constraintName());
+					String trimmedConstraintName = StringUtils.trimWhitespace(actionParameter.constraintName());
+					final String constraintName = trimmedConstraintName.isEmpty() ? null : trimmedConstraintName;
 					final ParameterDefinition parameterDefinition = new ParameterDefinitionImpl(name,
 							dataType.getName(), mandatory, displayLabel, multivalued, constraintName);
 					parameterDefinitions.add(parameterDefinition);
@@ -249,7 +250,7 @@ public class AnnotationBasedActionRegistrar extends AbstractAnnotationBasedRegis
 
 	private DataTypeDefinition getDataType(final Class<?> clazz, final ActionParam actionParameter) {
 		final DataTypeDefinition dataType;
-		if (StringUtils.isNotEmpty(actionParameter.type())) {
+		if (!StringUtils.isEmpty(actionParameter.type())) {
 			dataType = getDictionaryService().getDataType(parseQName(actionParameter.type(), actionParameter));
 			if (dataType == null) {
 				throw new RuntimeException(String.format("Invalid or unknown DataType: %s", actionParameter.type()));

--- a/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/actions/TestAction.java
+++ b/integration-tests/test-bundle/src/main/java/eu/xenit/de/testing/actions/TestAction.java
@@ -1,0 +1,16 @@
+package eu.xenit.de.testing.actions;
+
+import com.github.dynamicextensionsalfresco.actions.annotations.ActionMethod;
+import com.github.dynamicextensionsalfresco.actions.annotations.ActionParam;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TestAction {
+
+    @ActionMethod(value = "testAction")
+    public void testAction(final NodeRef nodeRef, @ActionParam("name") final String name) {
+        throw new UnsupportedOperationException();
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Switched the `StringUtils` used in `AnnotationBasedActionRegistrar` to the one from spring core instead of the commons lang library, which is no longer included in Alfresco 7.0.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#338 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The apache commons lang library is no longer included in Alfresco 7.0. `AnnotationBasedActionRegistrar` is the only class where this library is used.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added an action using `@ActionMethod` to the integration test bundle.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the changelog.
